### PR TITLE
add test case for optional fields on recursive type

### DIFF
--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -275,17 +275,49 @@ function visitRegularObjectType(type: ts.ObjectType, visitorContext: VisitorCont
                     const functionName = visitType(propertyInfo.type, visitorContext);
                     return ts.createBlock([
                         ts.createIf(
-                            ts.createLogicalNot(
-                                ts.createBinary(
-                                    ts.createStringLiteral(propertyInfo.name),
-                                    ts.SyntaxKind.InKeyword,
-                                    objectIdentifier
-                                )
+                            ts.createBinary(
+                                ts.createStringLiteral(propertyInfo.name),
+                                ts.SyntaxKind.InKeyword,
+                                objectIdentifier
                             ),
-                            ts.createReturn(
-                                propertyInfo.optional
-                                    ? ts.createNull()
-                                    : VisitorUtils.createBinaries(
+                            ts.createBlock([
+                                ts.createExpressionStatement(
+                                    ts.createCall(
+                                        ts.createPropertyAccess(pathIdentifier, 'push'),
+                                        undefined,
+                                        [ts.createStringLiteral(propertyInfo.name)]
+                                    )
+                                ),
+                                ts.createVariableStatement(
+                                    [ts.createModifier(ts.SyntaxKind.ConstKeyword)],
+                                    [
+                                        ts.createVariableDeclaration(
+                                            errorIdentifier,
+                                            undefined,
+                                            ts.createCall(
+                                                ts.createIdentifier(functionName),
+                                                undefined,
+                                                [ts.createElementAccess(objectIdentifier, ts.createStringLiteral(propertyInfo.name))]
+                                            )
+                                        )
+                                    ]
+                                ),
+                                ts.createExpressionStatement(
+                                    ts.createCall(
+                                        ts.createPropertyAccess(pathIdentifier, 'pop'),
+                                        undefined,
+                                        undefined
+                                    )
+                                ),
+                                ts.createIf(
+                                    errorIdentifier,
+                                    ts.createReturn(errorIdentifier)
+                                )
+                            ]),
+                            propertyInfo.optional
+                                ? undefined
+                                : ts.createReturn(
+                                    VisitorUtils.createBinaries(
                                         [
                                             ts.createStringLiteral('validation failed at '),
                                             ts.createCall(
@@ -300,39 +332,7 @@ function visitRegularObjectType(type: ts.ObjectType, visitorContext: VisitorCont
                                         ],
                                         ts.SyntaxKind.PlusToken
                                     )
-                            )
-                        ),
-                        ts.createExpressionStatement(
-                            ts.createCall(
-                                ts.createPropertyAccess(pathIdentifier, 'push'),
-                                undefined,
-                                [ts.createStringLiteral(propertyInfo.name)]
-                            )
-                        ),
-                        ts.createVariableStatement(
-                            [ts.createModifier(ts.SyntaxKind.ConstKeyword)],
-                            [
-                                ts.createVariableDeclaration(
-                                    errorIdentifier,
-                                    undefined,
-                                    ts.createCall(
-                                        ts.createIdentifier(functionName),
-                                        undefined,
-                                        [ts.createElementAccess(objectIdentifier, ts.createStringLiteral(propertyInfo.name))]
-                                    )
                                 )
-                            ]
-                        ),
-                        ts.createExpressionStatement(
-                            ts.createCall(
-                                ts.createPropertyAccess(pathIdentifier, 'pop'),
-                                undefined,
-                                undefined
-                            )
-                        ),
-                        ts.createIf(
-                            errorIdentifier,
-                            ts.createReturn(errorIdentifier)
                         )
                     ]);
                 }),

--- a/test/issue-12.ts
+++ b/test/issue-12.ts
@@ -75,4 +75,15 @@ describe('is', () => {
             assert.strictEqual(is<DirectlyRecursive>({ child: { child: {} } }), false);
         });
     });
+    
+    interface OptionalFieldsRecursive {
+        folder?: string;
+        children: OptionalFieldsRecursive[];
+    }
+    describe('is<OptionalFieldsRecursive>', () => {
+        it('should return false for invalid recursive ConfigInit objects', () => {
+            assert.strictEqual(is<OptionalFieldsRecursive>({ children: [] }), true);
+            assert.strictEqual(is<OptionalFieldsRecursive>({}), false);
+        })
+    })
 });

--- a/test/issue-12.ts
+++ b/test/issue-12.ts
@@ -80,9 +80,13 @@ describe('is', () => {
         folder?: string;
         children: OptionalFieldsRecursive[];
     }
+
     describe('is<OptionalFieldsRecursive>', () => {
-        it('should return false for invalid recursive ConfigInit objects', () => {
+        it('should return true for valid recursive OptionalFieldsRecursive objects', () => {
             assert.strictEqual(is<OptionalFieldsRecursive>({ children: [] }), true);
+        });
+
+        it('should return false for invalid recursive OptionalFieldsRecursive objects', () => {
             assert.strictEqual(is<OptionalFieldsRecursive>({}), false);
         });
     });

--- a/test/issue-12.ts
+++ b/test/issue-12.ts
@@ -75,7 +75,7 @@ describe('is', () => {
             assert.strictEqual(is<DirectlyRecursive>({ child: { child: {} } }), false);
         });
     });
-    
+
     interface OptionalFieldsRecursive {
         folder?: string;
         children: OptionalFieldsRecursive[];
@@ -84,6 +84,6 @@ describe('is', () => {
         it('should return false for invalid recursive ConfigInit objects', () => {
             assert.strictEqual(is<OptionalFieldsRecursive>({ children: [] }), true);
             assert.strictEqual(is<OptionalFieldsRecursive>({}), false);
-        })
-    })
+        });
+    });
 });


### PR DESCRIPTION
feel free to close this pr, it has been created to assist with #12, and is failing on purpose. Optional fields on recursive object types appear to validate any object as the correct type