### PR TITLE
Pick up identifier name

### DIFF
--- a/src/transform-inline/transform-node.ts
+++ b/src/transform-inline/transform-node.ts
@@ -5,7 +5,7 @@ import { visitType, visitUndefinedOrType, visitShortCircuit } from './visitor-ty
 import * as VisitorUtils from './visitor-utils';
 import { sliceMapValues } from './utils';
 
-function createArrowFunction(type: ts.Type, optional: boolean, partialVisitorContext: PartialVisitorContext) {
+function createArrowFunction(type: ts.Type, name: string, optional: boolean, partialVisitorContext: PartialVisitorContext) {
     const functionMap: VisitorContext['functionMap'] = new Map();
     const functionNames: VisitorContext['functionNames'] = new Set();
     const visitorContext = { ...partialVisitorContext, functionNames, functionMap };
@@ -37,7 +37,7 @@ function createArrowFunction(type: ts.Type, optional: boolean, partialVisitorCon
         ts.createBlock([
             ts.createVariableStatement(
                 [ts.createModifier(ts.SyntaxKind.ConstKeyword)],
-                [ts.createVariableDeclaration(VisitorUtils.pathIdentifier, undefined, ts.createArrayLiteral([ts.createStringLiteral('$')]))]
+                [ts.createVariableDeclaration(VisitorUtils.pathIdentifier, undefined, ts.createArrayLiteral([ts.createStringLiteral(name)]))]
             ),
             ...declarations,
             ts.createVariableStatement(
@@ -49,7 +49,7 @@ function createArrowFunction(type: ts.Type, optional: boolean, partialVisitorCon
     );
 }
 
-function transformDecorator(node: ts.Decorator, parameterType: ts.Type, optional: boolean, visitorContext: PartialVisitorContext): ts.Decorator {
+function transformDecorator(node: ts.Decorator, parameterType: ts.Type, parameterName: string, optional: boolean, visitorContext: PartialVisitorContext): ts.Decorator {
     if (ts.isCallExpression(node.expression)) {
         const signature = visitorContext.checker.getResolvedSignature(node.expression);
         if (
@@ -58,7 +58,7 @@ function transformDecorator(node: ts.Decorator, parameterType: ts.Type, optional
             && path.resolve(signature.declaration.getSourceFile().fileName) === path.resolve(path.join(__dirname, '..', '..', 'index.d.ts'))
             && node.expression.arguments.length <= 1
         ) {
-            const arrowFunction: ts.Expression = createArrowFunction(parameterType, optional, visitorContext);
+            const arrowFunction: ts.Expression = createArrowFunction(parameterType, parameterName, optional, visitorContext);
             const expression = ts.updateCall(
                 node.expression,
                 node.expression.expression,
@@ -74,11 +74,15 @@ function transformDecorator(node: ts.Decorator, parameterType: ts.Type, optional
     return node;
 }
 
+function extractVariableName(node: ts.Node) {
+    return ts.isIdentifier(node) ? node.escapedText.toString() : '$';
+}
+
 export function transformNode(node: ts.Node, visitorContext: PartialVisitorContext): ts.Node {
     if (ts.isParameter(node) && node.type !== undefined && node.decorators !== undefined) {
         const type = visitorContext.checker.getTypeFromTypeNode(node.type);
         const required = !node.initializer && !node.questionToken;
-        const mappedDecorators = node.decorators.map((decorator) => transformDecorator(decorator, type, !required, visitorContext));
+        const mappedDecorators = node.decorators.map((decorator) => transformDecorator(decorator, type, extractVariableName(node.name), !required, visitorContext));
         return ts.updateParameter(
             node,
             mappedDecorators,
@@ -105,6 +109,7 @@ export function transformNode(node: ts.Node, visitorContext: PartialVisitorConte
             const type = visitorContext.checker.getTypeFromTypeNode(typeArgument);
             const arrowFunction = createArrowFunction(
                 type,
+                node.arguments.length > 0 ? extractVariableName(node.arguments[0]) : '$',
                 false,
                 {
                     ...visitorContext,

--- a/test/case-11.ts
+++ b/test/case-11.ts
@@ -24,7 +24,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-numbers', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected a number$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a number$/;
             assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('0' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('1' as any), expectedMessageRegExp);
@@ -52,7 +52,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-strings', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected a string$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a string$/;
             assert.throws(() => instance.testMethod(0 as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod(1 as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod(true as any), expectedMessageRegExp);

--- a/test/case-15.ts
+++ b/test/case-15.ts
@@ -29,7 +29,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-numbers', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected a number$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a number$/;
             assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('0' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('1' as any), expectedMessageRegExp);
@@ -67,7 +67,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-numbers', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected a number$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a number$/;
             assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('0' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('1' as any), expectedMessageRegExp);

--- a/test/case-9.ts
+++ b/test/case-9.ts
@@ -21,7 +21,7 @@ describe('assertType', () => {
             assert.throws(() => assertType<number>(true), expectedMessageRegExp);
             assert.throws(() => assertType<number>(false), expectedMessageRegExp);
             assert.throws(() => assertType<number>(null), expectedMessageRegExp);
-            assert.throws(() => assertType<number>(undefined), expectedMessageRegExp);
+            assert.throws(() => assertType<number>(undefined), /validation failed at undefined: expected a number$/);
         });
     });
 });

--- a/test/root-name.ts
+++ b/test/root-name.ts
@@ -1,8 +1,6 @@
 import * as assert from 'assert';
 import { AssertType, assertType, ValidateClass } from '../index';
 
-/* https://github.com/woutervh-/typescript-is/issues/43 */
-
 describe('is', () => {
     type Foo = {a: string};
 

--- a/test/root-name.ts
+++ b/test/root-name.ts
@@ -1,0 +1,35 @@
+import * as assert from 'assert';
+import { AssertType, assertType, ValidateClass } from '../index';
+
+/* https://github.com/woutervh-/typescript-is/issues/43 */
+
+describe('is', () => {
+    type Foo = {a: string};
+
+    @ValidateClass()
+    class TestClass {
+        testIdentifier(@AssertType() fooParam: Foo) {
+            return fooParam;
+        }
+        testExpression(@AssertType() {a}: Foo) {
+            return a;
+        }
+    }
+
+    describe('root name detection', () => {
+        it('should default to "$"', () => {
+            const testClass = new TestClass();
+            assert.throws(() => assertType<Foo>([1, 'a']), /validation failed at \$/);
+            assert.throws(() => testClass.testExpression(123 as any), /validation failed at \$/);
+        });
+        it('should pick up identifier name', () => {
+            const testClass = new TestClass();
+            const testVar = 123 as any;
+            assert.throws(() => assertType<Foo>(testVar), /validation failed at testVar/);
+            assert.throws(() => testClass.testIdentifier(123 as any), /validation failed at fooParam/);
+        });
+        it('should pick up undefined', () => {
+            assert.throws(() => assertType<number>(undefined), /validation failed at undefined/);
+        });
+    });
+});


### PR DESCRIPTION
Enhance error messages by using the actual name of the checked symbol instead of just `$` when possible.

Example:

```
@ValidateClass()
class MyClass {
    myMethod(@AssertType() make, @AssertType() model) { }
}
```

Before: `validation failed at $: expected 'type' in object` (Can't tell which parameter failed)
After: `validation failed at model: expected 'type' in object` (More useful)

---

This code is just a quick and dirty PoC. I can clean it up if you are open to this enhancement.
