### PR TITLE
Update README with note about ts-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ module.exports = {
 };
 ```
 
+Note: This will not work if `ts-loader` is configured with `transpileOnly: true`.
+
 ## Options
 
 There are some options to configure the transformer.


### PR DESCRIPTION
The typescript-is transform doesn't work with ts-loader if it's configured with `transpileOnly: true`.
This is a pretty popular configuration (combined with a forked type-checker), and seems worth calling out here. I lost a day to this recently and would like to save others the trouble!