### PR TITLE
added support for Date

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 lib/
 test/*.js
+.idea

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ There are some options to configure the transformer.
 | Property | Description |
 |--|--|
 | `shortCircuit` | Boolean (default `false`). If `true`, all type guards will return `true`, i.e. no validation takes place. Can be used for example in production deployments where doing a lot of validation can cost too much CPU. |
-| `ignoreClasses` | Boolean (default: `false`). If `true`, when the transformer encounters a class, it will ignore it and simply return `true`. If `false`, an error is generated at compile time. |
+| `ignoreClasses` | Boolean (default: `false`). If `true`, when the transformer encounters a class (except for `Date`), it will ignore it and simply return `true`. If `false`, an error is generated at compile time. |
 | `ignoreMethods` | Boolean (default: `false`). If `true`, when the transformer encounters a method, it will ignore it and simply return `true`. If `false`, an error is generated at compile time. |
 | `ignoreFunctions` | Boolean (default: `false`). If `true`, when the transformer encounters a function, it will ignore it and simply return `true`. If `false`, an error is generated at compile time. |
 | `disallowSuperfluousObjectProperties` | Boolean (default: `false`). If `true`, objects are checked for having superfluous properties and will cause the validation to fail if they do. If `false`, no check for superfluous properties is made. |
@@ -279,7 +279,7 @@ There you can find all the different types that are tested for.
 
 * This library aims to be able to check any serializable data.
 * This library will not check functions. Function signatures are impossible to check at run-time.
-* This library will not check classes. Instead, you are encouraged to use the native `instanceof` operator. For example:
+* This library will not check classes (except the global `Date`). Instead, you are encouraged to use the native `instanceof` operator. For example:
 
 ```typescript
 import { is } from 'typescript-is';

--- a/index.d.ts
+++ b/index.d.ts
@@ -204,6 +204,10 @@ interface ExpectedObject {
     type: 'object';
 }
 
+interface ExpectedDate {
+    type: 'Date';
+}
+
 interface ExpectedNonPrimitive {
     type: 'non-primitive';
 }
@@ -253,6 +257,7 @@ type Reason = ExpectedString
     | ExpectedBigInt
     | ExpectedBoolean
     | ExpectedObject
+    | ExpectedDate
     | ExpectedNonPrimitive
     | MissingObjectProperty
     | SuperfluousObjectProperty

--- a/index.d.ts
+++ b/index.d.ts
@@ -205,7 +205,7 @@ interface ExpectedObject {
 }
 
 interface ExpectedDate {
-    type: 'Date';
+    type: 'date';
 }
 
 interface ExpectedNonPrimitive {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-is",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-is",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "engines": {
     "node": ">=6.14.4"
   },

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -379,7 +379,17 @@ function visitTypeParameter(type: ts.Type, visitorContext: VisitorContext) {
 
 function visitObjectType(type: ts.ObjectType, visitorContext: VisitorContext) {
     if (VisitorUtils.checkIsClass(type, visitorContext)) {
-        return VisitorUtils.getIgnoredTypeFunction(visitorContext);
+        if (VisitorUtils.checkIsDateClass(type, visitorContext)) {
+            // TODO: change this to be a validator for Date or something along the lines of what happens to other types
+            console.log('yay, date object!')
+            return VisitorUtils.getIgnoredTypeFunction(visitorContext);
+        }
+
+        if (visitorContext.options.ignoreClasses) {
+            return VisitorUtils.getIgnoredTypeFunction(visitorContext);
+        } else {
+            throw new Error('Classes cannot be validated. https://github.com/woutervh-/typescript-is/issues/3');
+        }
     }
     if (tsutils.isTupleType(type)) {
         // Tuple with finite length.

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -9,7 +9,7 @@ import * as VisitorTypeName from './visitor-type-name';
 import { sliceSet } from './utils';
 
 function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
-    const name = VisitorTypeName.visitType(type, visitorContext, {type: 'type-check'});
+    const name = VisitorTypeName.visitType(type, visitorContext, { type: 'type-check' });
     return VisitorUtils.setFunctionIfNotExists(name, visitorContext, () => {
         return ts.createFunctionDeclaration(
             undefined,
@@ -56,59 +56,14 @@ function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
                         ))
                     ),
                     ts.createIf(
-                        ts.createPrefix(
-                            ts.SyntaxKind.ExclamationToken,
-                            ts.createParen(ts.createBinary(
+                        ts.createLogicalNot(
+                            ts.createBinary(
                                 ts.createIdentifier('object'),
                                 ts.createToken(ts.SyntaxKind.InstanceOfKeyword),
                                 ts.createIdentifier('nativeDateObject')
-                            ))
+                            )
                         ),
-                        ts.createReturn(ts.createObjectLiteral(
-                            [
-                                ts.createPropertyAssignment(
-                                    ts.createIdentifier('message'),
-                                    ts.createBinary(
-                                        ts.createBinary(
-                                            ts.createStringLiteral('validation failed at '),
-                                            ts.createToken(ts.SyntaxKind.PlusToken),
-                                            ts.createCall(
-                                                ts.createPropertyAccess(
-                                                    ts.createIdentifier('path'),
-                                                    ts.createIdentifier('join')
-                                                ),
-                                                undefined,
-                                                [ts.createStringLiteral('.')]
-                                            )
-                                        ),
-                                        ts.createToken(ts.SyntaxKind.PlusToken),
-                                        ts.createStringLiteral(': expected a Date')
-                                    )
-                                ),
-                                ts.createPropertyAssignment(
-                                    ts.createIdentifier('path'),
-                                    ts.createCall(
-                                        ts.createPropertyAccess(
-                                            ts.createIdentifier('path'),
-                                            ts.createIdentifier('slice')
-                                        ),
-                                        undefined,
-                                        []
-                                    )
-                                ),
-                                ts.createPropertyAssignment(
-                                    ts.createIdentifier('reason'),
-                                    ts.createObjectLiteral(
-                                        [ts.createPropertyAssignment(
-                                            ts.createIdentifier('type'),
-                                            ts.createStringLiteral('Date')
-                                        )],
-                                        false
-                                    )
-                                )
-                            ],
-                            true
-                        )),
+                        ts.createReturn(VisitorUtils.createErrorObject({ type: 'date' })),
                         ts.createReturn(ts.createNull())
                     )],
                 true

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -27,7 +27,10 @@ function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
                         ts.createParen(ts.createBinary(
                             ts.createIdentifier('object'),
                             ts.createToken(ts.SyntaxKind.InstanceOfKeyword),
-                            ts.createIdentifier('Date')
+                            ts.createPropertyAccess(
+                                ts.createIdentifier('global'),
+                                ts.createIdentifier('Date')
+                            )
                         ))
                     ),
                     ts.createReturn(ts.createObjectLiteral(

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -8,6 +8,13 @@ import * as VisitorIsStringKeyof from './visitor-is-string-keyof';
 import * as VisitorTypeName from './visitor-type-name';
 import { sliceSet } from './utils';
 
+function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
+    console.log('yay, date object!')
+
+    // TODO: change this to return a validator for Date objects
+    return VisitorUtils.getIgnoredTypeFunction(visitorContext);
+}
+
 function visitTupleObjectType(type: ts.TupleType, visitorContext: VisitorContext) {
     const name = VisitorTypeName.visitType(type, visitorContext, { type: 'type-check' });
     return VisitorUtils.setFunctionIfNotExists(name, visitorContext, () => {
@@ -380,9 +387,7 @@ function visitTypeParameter(type: ts.Type, visitorContext: VisitorContext) {
 function visitObjectType(type: ts.ObjectType, visitorContext: VisitorContext) {
     if (VisitorUtils.checkIsClass(type, visitorContext)) {
         if (VisitorUtils.checkIsDateClass(type, visitorContext)) {
-            // TODO: change this to be a validator for Date or something along the lines of what happens to other types
-            console.log('yay, date object!')
-            return VisitorUtils.getIgnoredTypeFunction(visitorContext);
+            visitDateType(type, visitorContext);
         }
 
         if (visitorContext.options.ignoreClasses) {

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -20,65 +20,97 @@ function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
             [ts.createParameter(undefined, undefined, undefined, VisitorUtils.objectIdentifier, undefined, undefined, undefined)],
             undefined,
             ts.createBlock(
-                [ts.createIf(
-                    ts.createPrefix(
-                        ts.SyntaxKind.ExclamationToken,
-                        ts.createParen(ts.createBinary(
-                            ts.createIdentifier('object'),
-                            ts.createToken(ts.SyntaxKind.InstanceOfKeyword),
+                [
+                    ts.createVariableStatement(
+                        undefined,
+                        ts.createVariableDeclarationList(
+                            [ts.createVariableDeclaration(
+                                ts.createIdentifier('nativeDateObject'),
+                                undefined,
+                                undefined
+                            )],
+                            ts.NodeFlags.Let
+                        )
+                    ),
+                    ts.createIf(
+                        ts.createBinary(
+                            ts.createTypeOf(ts.createIdentifier('global')),
+                            ts.createToken(ts.SyntaxKind.EqualsEqualsEqualsToken),
+                            ts.createStringLiteral('undefined')
+                        ),
+                        ts.createExpressionStatement(ts.createBinary(
+                            ts.createIdentifier('nativeDateObject'),
+                            ts.createToken(ts.SyntaxKind.EqualsToken),
+                            ts.createPropertyAccess(
+                                ts.createIdentifier('window'),
+                                ts.createIdentifier('Date')
+                            )
+                        )),
+                        ts.createExpressionStatement(ts.createBinary(
+                            ts.createIdentifier('nativeDateObject'),
+                            ts.createToken(ts.SyntaxKind.EqualsToken),
                             ts.createPropertyAccess(
                                 ts.createIdentifier('global'),
                                 ts.createIdentifier('Date')
                             )
                         ))
                     ),
-                    ts.createReturn(ts.createObjectLiteral(
-                        [
-                            ts.createPropertyAssignment(
-                                ts.createIdentifier('message'),
-                                ts.createBinary(
+                    ts.createIf(
+                        ts.createPrefix(
+                            ts.SyntaxKind.ExclamationToken,
+                            ts.createParen(ts.createBinary(
+                                ts.createIdentifier('object'),
+                                ts.createToken(ts.SyntaxKind.InstanceOfKeyword),
+                                ts.createIdentifier('nativeDateObject')
+                            ))
+                        ),
+                        ts.createReturn(ts.createObjectLiteral(
+                            [
+                                ts.createPropertyAssignment(
+                                    ts.createIdentifier('message'),
                                     ts.createBinary(
-                                        ts.createStringLiteral('validation failed at '),
+                                        ts.createBinary(
+                                            ts.createStringLiteral('validation failed at '),
+                                            ts.createToken(ts.SyntaxKind.PlusToken),
+                                            ts.createCall(
+                                                ts.createPropertyAccess(
+                                                    ts.createIdentifier('path'),
+                                                    ts.createIdentifier('join')
+                                                ),
+                                                undefined,
+                                                [ts.createStringLiteral('.')]
+                                            )
+                                        ),
                                         ts.createToken(ts.SyntaxKind.PlusToken),
-                                        ts.createCall(
-                                            ts.createPropertyAccess(
-                                                ts.createIdentifier('path'),
-                                                ts.createIdentifier('join')
-                                            ),
-                                            undefined,
-                                            [ts.createStringLiteral('.')]
-                                        )
-                                    ),
-                                    ts.createToken(ts.SyntaxKind.PlusToken),
-                                    ts.createStringLiteral(': expected a Date')
+                                        ts.createStringLiteral(': expected a Date')
+                                    )
+                                ),
+                                ts.createPropertyAssignment(
+                                    ts.createIdentifier('path'),
+                                    ts.createCall(
+                                        ts.createPropertyAccess(
+                                            ts.createIdentifier('path'),
+                                            ts.createIdentifier('slice')
+                                        ),
+                                        undefined,
+                                        []
+                                    )
+                                ),
+                                ts.createPropertyAssignment(
+                                    ts.createIdentifier('reason'),
+                                    ts.createObjectLiteral(
+                                        [ts.createPropertyAssignment(
+                                            ts.createIdentifier('type'),
+                                            ts.createStringLiteral('Date')
+                                        )],
+                                        false
+                                    )
                                 )
-                            ),
-                            ts.createPropertyAssignment(
-                                ts.createIdentifier('path'),
-                                ts.createCall(
-                                    ts.createPropertyAccess(
-                                        ts.createIdentifier('path'),
-                                        ts.createIdentifier('slice')
-                                    ),
-                                    undefined,
-                                    []
-                                )
-                            ),
-                            ts.createPropertyAssignment(
-                                ts.createIdentifier('reason'),
-                                ts.createObjectLiteral(
-                                    [ts.createPropertyAssignment(
-                                        ts.createIdentifier('type'),
-                                        ts.createStringLiteral('Date')
-                                    )],
-                                    false
-                                )
-                            )
-                        ],
-                        true
-                    )),
-                    ts.createReturn(ts.createNull())
-                )],
+                            ],
+                            true
+                        )),
+                        ts.createReturn(ts.createNull())
+                    )],
                 true
             )
         )

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -9,7 +9,6 @@ import * as VisitorTypeName from './visitor-type-name';
 import { sliceSet } from './utils';
 
 function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
-    // TODO: fix name (currently something like "_1055", should be "_date"), expand VisitorTypeName.visitType to do so?
     const name = VisitorTypeName.visitType(type, visitorContext, {type: 'type-check'});
     return VisitorUtils.setFunctionIfNotExists(name, visitorContext, () => {
         return ts.createFunctionDeclaration(

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -458,7 +458,7 @@ function visitTypeParameter(type: ts.Type, visitorContext: VisitorContext) {
 function visitObjectType(type: ts.ObjectType, visitorContext: VisitorContext) {
     if (VisitorUtils.checkIsClass(type, visitorContext)) {
         // Dates
-        if (VisitorUtils.checkIsDateClass(type, visitorContext)) {
+        if (VisitorUtils.checkIsDateClass(type)) {
             return visitDateType(type, visitorContext);
         }
 

--- a/src/transform-inline/visitor-type-name.ts
+++ b/src/transform-inline/visitor-type-name.ts
@@ -4,6 +4,7 @@ import { VisitorContext } from './visitor-context';
 import * as VisitorUtils from './visitor-utils';
 import * as VisitorKeyof from './visitor-keyof';
 import * as VisitorIndexedAccess from './visitor-indexed-access';
+import {checkIsDateClass} from './visitor-utils';
 
 interface TypeCheckNameMode {
     type: 'type-check';
@@ -67,6 +68,8 @@ function visitObjectType(type: ts.ObjectType, visitorContext: VisitorContext, mo
         return visitTupleObjectType(type, visitorContext, mode);
     } else if (visitorContext.checker.getIndexTypeOfType(type, ts.IndexKind.Number)) {
         return visitArrayObjectType(type, visitorContext, mode);
+    } else if (checkIsDateClass(type)) {
+        return '_date';
     } else {
         return visitRegularObjectType(type);
     }

--- a/src/transform-inline/visitor-type-name.ts
+++ b/src/transform-inline/visitor-type-name.ts
@@ -4,7 +4,7 @@ import { VisitorContext } from './visitor-context';
 import * as VisitorUtils from './visitor-utils';
 import * as VisitorKeyof from './visitor-keyof';
 import * as VisitorIndexedAccess from './visitor-indexed-access';
-import {checkIsDateClass} from './visitor-utils';
+import { checkIsDateClass } from './visitor-utils';
 
 interface TypeCheckNameMode {
     type: 'type-check';

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -1,7 +1,8 @@
 import * as ts from 'typescript';
+import {ModifierFlags} from 'typescript';
 import * as tsutils from 'tsutils/typeguard/3.0';
-import { VisitorContext } from './visitor-context';
-import { Reason } from '../../index';
+import {VisitorContext} from './visitor-context';
+import {Reason} from '../../index';
 
 export const objectIdentifier = ts.createIdentifier('object');
 export const pathIdentifier = ts.createIdentifier('path');
@@ -24,15 +25,18 @@ export function checkIsClass(type: ts.ObjectType, visitorContext: VisitorContext
     }
 
     if (type.isClass() || hasConstructSignatures) {
-        return true
+        return true;
     } else {
         return false;
     }
 }
 
-export function checkIsDateClass(type: ts.ObjectType, visitorContext: VisitorContext) {
-    if (type.symbol !== undefined && type.symbol.escapedName === 'Date') {
-        // TODO: do proper type check
+export function checkIsDateClass(type: ts.ObjectType) {
+    if (
+        type.symbol !== undefined
+        && type.symbol.escapedName === 'Date'
+        && (ts.getCombinedModifierFlags(type.symbol.valueDeclaration) & ModifierFlags.Ambient) !== 0
+    ) {
         return true;
     }
 }

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -1,8 +1,8 @@
 import * as ts from 'typescript';
-import {ModifierFlags} from 'typescript';
+import { ModifierFlags } from 'typescript';
 import * as tsutils from 'tsutils/typeguard/3.0';
-import {VisitorContext} from './visitor-context';
-import {Reason} from '../../index';
+import { VisitorContext } from './visitor-context';
+import { Reason } from '../../index';
 
 export const objectIdentifier = ts.createIdentifier('object');
 export const pathIdentifier = ts.createIdentifier('path');
@@ -596,5 +596,7 @@ function createErrorMessage(reason: Reason): ts.Expression {
             return createAssertionString(`expected ${reason.value ? 'true' : 'false'}`);
         case 'non-primitive':
             return createAssertionString('expected a non-primitive');
+        case 'date':
+            return createAssertionString('expected a Date');
     }
 }

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -24,13 +24,16 @@ export function checkIsClass(type: ts.ObjectType, visitorContext: VisitorContext
     }
 
     if (type.isClass() || hasConstructSignatures) {
-        if (visitorContext.options.ignoreClasses) {
-            return true;
-        } else {
-            throw new Error('Classes cannot be validated. https://github.com/woutervh-/typescript-is/issues/3');
-        }
+        return true
     } else {
         return false;
+    }
+}
+
+export function checkIsDateClass(type: ts.ObjectType, visitorContext: VisitorContext) {
+    if (type.symbol !== undefined && type.symbol.escapedName === 'Date') {
+        // TODO: do proper type check
+        return true;
     }
 }
 

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -24,11 +24,7 @@ export function checkIsClass(type: ts.ObjectType, visitorContext: VisitorContext
         hasConstructSignatures = constructSignatures.length >= 1;
     }
 
-    if (type.isClass() || hasConstructSignatures) {
-        return true;
-    } else {
-        return false;
-    }
+    return type.isClass() || hasConstructSignatures;
 }
 
 export function checkIsDateClass(type: ts.ObjectType) {

--- a/test-fixtures/issue-16-a.ts
+++ b/test-fixtures/issue-16-a.ts
@@ -1,9 +1,6 @@
 import { is } from '../index';
 
-class ClassX {
-    method() {
-        //
-    }
-}
+// overwriting the global Date with a custom class, this isn't supported and should raise an error if ignoreClasses is false
+class Date {}
 
-is<ClassX>(new ClassX()); // ignore when ignoreClasses is true
+is<Date>(new Date()); // ignore when ignoreClasses is true

--- a/test-fixtures/issue-16-c.ts
+++ b/test-fixtures/issue-16-c.ts
@@ -1,3 +1,3 @@
 import { is } from '../index';
 
-is<Date>({}); // Ignore when ignoreClasses and ignoreMethods are true.
+is<Date>({}); // Do NOT ignore when ignoreClasses and ignoreMethods are false.

--- a/test-fixtures/issue-31-a.ts
+++ b/test-fixtures/issue-31-a.ts
@@ -1,0 +1,5 @@
+import { is } from '../index';
+
+class Test {}
+
+is<Test>(null); // ignore when ignoreClasses is true

--- a/test-fixtures/issue-31-b.ts
+++ b/test-fixtures/issue-31-b.ts
@@ -1,0 +1,3 @@
+import { is } from '../index';
+
+is<Date>(null);

--- a/test-fixtures/issue-31.ts
+++ b/test-fixtures/issue-31.ts
@@ -1,3 +1,0 @@
-import { is } from '../index';
-
-is<Date>(null); // ignore when ignoreClasses is true

--- a/test/issue-16.ts
+++ b/test/issue-16.ts
@@ -86,8 +86,8 @@ describe('visitor', () => {
             program,
             compilerOptions: program.getCompilerOptions(),
             options: {
-                ignoreClasses: true,
-                ignoreMethods: true,
+                ignoreClasses: false,
+                ignoreMethods: false,
                 ignoreFunctions: false,
                 shortCircuit: false,
                 disallowSuperfluousObjectProperties: false
@@ -100,7 +100,7 @@ describe('visitor', () => {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
         }
 
-        it('should not throw an error for classes', () => {
+        it('should not throw an error for Date with ignoreClasses and ignoreMethods off', () => {
             visitNodeAndChildren(program.getSourceFile(inFile)!);
         });
     });

--- a/test/issue-16.ts
+++ b/test/issue-16.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import * as ts from 'typescript';
+import * as assert from 'assert';
 import { transformNode } from '../lib/transform-inline/transform-node';
 import { PartialVisitorContext } from '../lib/transform-inline/visitor-context';
 
@@ -25,27 +26,54 @@ describe('visitor', () => {
         const inFile = path.resolve(__dirname, '..', 'test-fixtures', 'issue-16-a.ts');
         const program = ts.createProgram([inFile], configParseResult.options);
 
-        const visitorContext: PartialVisitorContext = {
-            checker: program.getTypeChecker(),
-            program,
-            compilerOptions: program.getCompilerOptions(),
-            options: {
-                ignoreClasses: true,
-                ignoreMethods: false,
-                ignoreFunctions: false,
-                shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
-            },
-            typeMapperStack: [],
-            previousTypeReference: null
-        };
+        describe('ignoreClasses = true', () => {
+            const visitorContext: PartialVisitorContext = {
+                checker: program.getTypeChecker(),
+                program,
+                compilerOptions: program.getCompilerOptions(),
+                options: {
+                    ignoreClasses: true,
+                    ignoreMethods: false,
+                    ignoreFunctions: false,
+                    shortCircuit: false,
+                    disallowSuperfluousObjectProperties: false
+                },
+                typeMapperStack: [],
+                previousTypeReference: null
+            };
 
-        function visitNodeAndChildren(node: ts.Node) {
-            ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
-        }
+            function visitNodeAndChildren(node: ts.Node) {
+                ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
+            }
 
-        it('should not throw an error for classes', () => {
-            visitNodeAndChildren(program.getSourceFile(inFile)!);
+            it('should not throw an error for custom classes named `Date`', () => {
+                visitNodeAndChildren(program.getSourceFile(inFile)!);
+            });
+        });
+
+        describe('ignoreClasses = false', () => {
+            const visitorContext: PartialVisitorContext = {
+                checker: program.getTypeChecker(),
+                program,
+                compilerOptions: program.getCompilerOptions(),
+                options: {
+                    ignoreClasses: false,
+                    ignoreMethods: false,
+                    ignoreFunctions: false,
+                    shortCircuit: false,
+                    disallowSuperfluousObjectProperties: false
+                },
+                typeMapperStack: [],
+                previousTypeReference: null
+            };
+
+            function visitNodeAndChildren(node: ts.Node) {
+                ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
+            }
+
+            it('should throw an error for custom classes named `Date`', () => {
+                assert.throws(() => visitNodeAndChildren(program.getSourceFile(inFile)!));
+            });
         });
     });
 

--- a/test/issue-31.ts
+++ b/test/issue-31.ts
@@ -22,10 +22,13 @@ delete configParseResult.options.outFile;
 delete configParseResult.options.declaration;
 
 describe('visitor', () => {
-    const inFile = path.resolve(__dirname, '..', 'test-fixtures', 'issue-31.ts');
+    const inFile = path.resolve(__dirname, '..', 'test-fixtures', 'issue-31-a.ts');
     const program = ts.createProgram([inFile], configParseResult.options);
+    // TODO: uncomment the stuff in here and investigate the errors they produce
+    // const inFileWithDate = path.resolve(__dirname, '..', 'test-fixtures', 'issue-31-b.ts');
+    // const programWithDate = ts.createProgram([inFileWithDate], configParseResult.options);
 
-    describe('visitor test-fixtures/issue-31.ts with ignoreClasses: false', () => {
+    describe('visitor testing classes with ignoreClasses: false', () => {
         const visitorContext: PartialVisitorContext = {
             checker: program.getTypeChecker(),
             program,
@@ -45,16 +48,20 @@ describe('visitor', () => {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
         }
 
-        it('should throw an for interface with constructor signatures such as Date', () => {
+        it('should throw an error for interface with constructor signatures except for Date', () => {
             const expectedMessageRegExp = /Classes cannot be validated\. https:\/\/github\.com\/woutervh-\/typescript-is\/issues\/3$/;
 
             assert.throws(() => {
                 visitNodeAndChildren(program.getSourceFile(inFile)!);
             }, expectedMessageRegExp);
         });
+
+        // it('should not throw an error for interface with Date', () => {
+        //     visitNodeAndChildren(programWithDate.getSourceFile(inFileWithDate)!);
+        // });
     });
 
-    describe('visitor test-fixtures/issue-31.ts with ignoreClasses: true', () => {
+    describe('visitor testing classes with ignoreClasses: true', () => {
         const visitorContext: PartialVisitorContext = {
             checker: program.getTypeChecker(),
             program,
@@ -74,8 +81,12 @@ describe('visitor', () => {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
         }
 
-        it('should not throw an for interface with constructor signatures such as Date', () => {
+        it('should not throw an error for interface with constructor signatures with ignoreClasses=true', () => {
             visitNodeAndChildren(program.getSourceFile(inFile)!);
         });
+
+        // it('should not throw an error for interface with Date', () => {
+        //     visitNodeAndChildren(programWithDate.getSourceFile(inFileWithDate)!);
+        // });
     });
 });

--- a/test/issue-31.ts
+++ b/test/issue-31.ts
@@ -1,9 +1,9 @@
 import * as path from 'path';
 import * as assert from 'assert';
 import * as ts from 'typescript';
-import {transformNode} from '../lib/transform-inline/transform-node';
-import {PartialVisitorContext} from '../lib/transform-inline/visitor-context';
-import {Program} from 'typescript';
+import { transformNode } from '../lib/transform-inline/transform-node';
+import { PartialVisitorContext } from '../lib/transform-inline/visitor-context';
+import { Program } from 'typescript';
 
 /**
  * https://github.com/woutervh-/typescript-is/issues/31

--- a/test/issue-31.ts
+++ b/test/issue-31.ts
@@ -24,9 +24,8 @@ delete configParseResult.options.declaration;
 describe('visitor', () => {
     const inFile = path.resolve(__dirname, '..', 'test-fixtures', 'issue-31-a.ts');
     const program = ts.createProgram([inFile], configParseResult.options);
-    // TODO: uncomment the stuff in here and investigate the errors they produce
-    // const inFileWithDate = path.resolve(__dirname, '..', 'test-fixtures', 'issue-31-b.ts');
-    // const programWithDate = ts.createProgram([inFileWithDate], configParseResult.options);
+    const inFileWithDate = path.resolve(__dirname, '..', 'test-fixtures', 'issue-31-b.ts');
+    const programWithDate = ts.createProgram([inFileWithDate], configParseResult.options);
 
     describe('visitor testing classes with ignoreClasses: false', () => {
         const visitorContext: PartialVisitorContext = {
@@ -56,9 +55,9 @@ describe('visitor', () => {
             }, expectedMessageRegExp);
         });
 
-        // it('should not throw an error for interface with Date', () => {
-        //     visitNodeAndChildren(programWithDate.getSourceFile(inFileWithDate)!);
-        // });
+        it('should not throw an error for interface with Date', () => {
+            visitNodeAndChildren(programWithDate.getSourceFile(inFileWithDate)!);
+        });
     });
 
     describe('visitor testing classes with ignoreClasses: true', () => {
@@ -85,8 +84,8 @@ describe('visitor', () => {
             visitNodeAndChildren(program.getSourceFile(inFile)!);
         });
 
-        // it('should not throw an error for interface with Date', () => {
-        //     visitNodeAndChildren(programWithDate.getSourceFile(inFileWithDate)!);
-        // });
+        it('should not throw an error for interface with Date', () => {
+            visitNodeAndChildren(programWithDate.getSourceFile(inFileWithDate)!);
+        });
     });
 });


### PR DESCRIPTION
We needed support for Dates in interfaces so I've added it. This only targets the global Date class and does not add any support for any other classes.
I've made it so that the check still happens even if the "ignoreClasses" is set.
The relevant unit tests have been added/changed.