### PR TITLE
Append input found to error message in TypeGuardError

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -167,6 +167,7 @@ export function ValidateClass(errorConstructor?: { new(): Error }): <TFunction e
 export class TypeGuardError extends Error {
     public readonly path: string[];
     public readonly reason: Reason;
+    public readonly input: any;
 }
 
 interface ExpectedString {

--- a/index.d.ts
+++ b/index.d.ts
@@ -167,7 +167,7 @@ export function ValidateClass(errorConstructor?: { new(): Error }): <TFunction e
 export class TypeGuardError extends Error {
     public readonly path: string[];
     public readonly reason: Reason;
-    public readonly input: any;
+    public readonly input: unknown;
 }
 
 interface ExpectedString {

--- a/index.js
+++ b/index.js
@@ -11,19 +11,18 @@ const assertionsMetadataKey = Symbol('assertions');
 function inputObjectAtPath(path, inputObject) {
     let subField = inputObject;
     for (const key of path) {
-      if (key === "$" || key === 'undefined') {
-        continue;
-      }
-      subField =
-        subField[
-          key.startsWith("[") ? key.replace("[", "").replace("]", "") : key
+        if (key === "$" || key === 'undefined') {
+            continue;
+        }
+        subField = subField[
+            key.startsWith("[") ? key.replace("[", "").replace("]", "") : key
         ];
     }
-    return subField
+    return subField;
 }
 
 function appendInputToErrorMessage(message, path, inputObject) {
-    return message + ', found: ' + JSON.stringify(inputObjectAtPath(path, inputObject))
+    return message + ', found: ' + JSON.stringify(inputObjectAtPath(path, inputObject));
 }
 
 class TypeGuardError extends Error {
@@ -56,7 +55,7 @@ function ValidateClass(errorConstructor = TypeGuardError) {
                     for (let i = 0; i < assertions.length; i++) {
                         const errorObject = assertions[i].assertion(args[i]);
                         if (errorObject !== null) {
-                            throw new errorConstructor(errorObject, target);
+                            throw new errorConstructor(errorObject, args[i]);
                         }
                     }
                     return originalMethod.apply(this, args);

--- a/index.js
+++ b/index.js
@@ -10,12 +10,9 @@ const assertionsMetadataKey = Symbol('assertions');
 
 function inputObjectAtPath(path, inputObject) {
     let subField = inputObject;
-    for (const key of path) {
-        if (key === "$" || key === 'undefined') {
-            continue;
-        }
+    for (const key of path.slice(1)) {
         subField = subField[
-            key.startsWith("[") ? key.replace("[", "").replace("]", "") : key
+            key.startsWith("[") ? parseInt(key.replace("[", "").replace("]", "")) : key
         ];
     }
     return subField;

--- a/src/transform-inline/transform-node.ts
+++ b/src/transform-inline/transform-node.ts
@@ -76,7 +76,7 @@ function transformDecorator(node: ts.Decorator, parameterType: ts.Type, paramete
 
 /** Figures out an appropriate human-readable name for the variable designated by `node`. */
 function extractVariableName(node: ts.Node | undefined) {
-    return node != null && ts.isIdentifier(node) ? node.escapedText.toString() : '$';
+    return node !== undefined && ts.isIdentifier(node) ? node.escapedText.toString() : '$';
 }
 
 export function transformNode(node: ts.Node, visitorContext: PartialVisitorContext): ts.Node {

--- a/test/case-10.ts
+++ b/test/case-10.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { createIs, createAssertType } from '../index';
+import { createAssertType, createIs } from '../index';
 
 describe('createIs', () => {
     describe('createIs<number>', () => {
@@ -34,7 +34,7 @@ describe('createIs', () => {
 
 describe('createAssertType', () => {
     describe('createAssertType<number>', () => {
-        const expectedMessageRegExp = /validation failed at \$: expected a number$/;
+        const expectedMessageRegExp = /validation failed at \$: expected a number, found: .*$/;
         const assertNumber = createAssertType<number>();
 
         it('should return a function', () => {

--- a/test/case-11.ts
+++ b/test/case-11.ts
@@ -24,7 +24,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-numbers', () => {
-            const expectedMessageRegExp = /validation failed at parameter: expected a number$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a number, found: .*$/;
             assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('0' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('1' as any), expectedMessageRegExp);
@@ -52,7 +52,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-strings', () => {
-            const expectedMessageRegExp = /validation failed at parameter: expected a string$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a string, found: .*$/;
             assert.throws(() => instance.testMethod(0 as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod(1 as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod(true as any), expectedMessageRegExp);

--- a/test/case-15.ts
+++ b/test/case-15.ts
@@ -29,7 +29,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-numbers', () => {
-            const expectedMessageRegExp = /validation failed at parameter: expected a number$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a number, found: .*$/;
             assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('0' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('1' as any), expectedMessageRegExp);
@@ -67,7 +67,7 @@ describe('@ValidateClass, @AssertType', () => {
         });
 
         it('should throw an error for non-numbers', () => {
-            const expectedMessageRegExp = /validation failed at parameter: expected a number$/;
+            const expectedMessageRegExp = /validation failed at parameter: expected a number, found: .*$/;
             assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('0' as any), expectedMessageRegExp);
             assert.throws(() => instance.testMethod('1' as any), expectedMessageRegExp);

--- a/test/case-9.ts
+++ b/test/case-9.ts
@@ -3,7 +3,7 @@ import { assertType } from '../index';
 
 describe('assertType', () => {
     describe('assertType<number>', () => {
-        const expectedMessageRegExp = /validation failed at \$: expected a number$/;
+        const expectedMessageRegExp = /validation failed at \$: expected a number, found: .*$/;
 
         it('should return the numbers passed to it', () => {
             assert.deepStrictEqual(assertType<number>(-1), -1);
@@ -21,7 +21,7 @@ describe('assertType', () => {
             assert.throws(() => assertType<number>(true), expectedMessageRegExp);
             assert.throws(() => assertType<number>(false), expectedMessageRegExp);
             assert.throws(() => assertType<number>(null), expectedMessageRegExp);
-            assert.throws(() => assertType<number>(undefined), /validation failed at undefined: expected a number$/);
+            assert.throws(() => assertType<number>(undefined), /validation failed at undefined: expected a number, found: .*$/);
         });
     });
 });

--- a/test/issue-12.ts
+++ b/test/issue-12.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { is, assertType } from '../index';
+import { assertType, is } from '../index';
 
 /* https://github.com/woutervh-/typescript-is/issues/12 */
 
@@ -35,12 +35,12 @@ describe('is', () => {
 
     describe('assertType<ConfigInit>', () => {
         it('should throw an error when invalid objects are passed to it', () => {
-            const expectedMessageRegExp1 = /validation failed at \$: expected an object$/;
-            const expectedMessageRegExp2 = /validation failed at \$: expected 'folder' in object$/;
-            const expectedMessageRegExp3 = /validation failed at \$\.children: expected an array$/;
-            const expectedMessageRegExp4 = /validation failed at \$\.children\.\[0\]: expected an object$/;
-            const expectedMessageRegExp5 = /validation failed at \$\.children\.\[0\]: expected 'folder' in object$/;
-            const expectedMessageRegExp6 = /validation failed at \$\.children\.\[0\]\.children: expected an array$/;
+            const expectedMessageRegExp1 = /validation failed at \$: expected an object, found: .*$/;
+            const expectedMessageRegExp2 = /validation failed at \$: expected 'folder' in object, found: .*$/;
+            const expectedMessageRegExp3 = /validation failed at \$\.children: expected an array, found: .*$/;
+            const expectedMessageRegExp4 = /validation failed at \$\.children\.\[0\]: expected an object, found: .*$/;
+            const expectedMessageRegExp5 = /validation failed at \$\.children\.\[0\]: expected 'folder' in object, found: .*$/;
+            const expectedMessageRegExp6 = /validation failed at \$\.children\.\[0\]\.children: expected an array, found: .*$/;
             assert.throws(() => assertType<ConfigInit>(null), expectedMessageRegExp1);
             assert.throws(() => assertType<ConfigInit>({}), expectedMessageRegExp2);
             assert.throws(() => assertType<ConfigInit>({ folder: '.', children: 'foo' }), expectedMessageRegExp3);

--- a/test/issue-2.ts
+++ b/test/issue-2.ts
@@ -13,7 +13,7 @@ describe('assertType', () => {
         });
 
         it('should throw an error if invalid objects are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected an object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected an object, found: .*$/;
             assert.throws(() => assertType<{ foo: string }>(0), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: string }>([]), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: string }>(null), expectedMessageRegExp);
@@ -21,13 +21,13 @@ describe('assertType', () => {
         });
 
         it('should throw an error if objects without foo are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object, found: .*$/;
             assert.throws(() => assertType<{ foo: string }>({}), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: string }>({ bar: 'baz' }), expectedMessageRegExp);
         });
 
         it('should throw an error if objects with foo not a string are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$\.foo: expected a string$/;
+            const expectedMessageRegExp = /validation failed at \$\.foo: expected a string, found: .*$/;
             assert.throws(() => assertType<{ foo: string }>({ foo: 0 }), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: string }>({ foo: false }), expectedMessageRegExp);
         });
@@ -43,21 +43,21 @@ describe('assertType', () => {
         });
 
         it('should throw an error if objects without foo are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object, found: .*$/;
             assert.throws(() => assertType<{ foo: string }>({}), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: string }>({ bar: 'baz' }), expectedMessageRegExp);
         });
 
         it('should throw an error if invalid objects are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected an object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected an object, found: .*$/;
             assert.throws(() => assertType<{ foo: number[] }>(0), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: number[] }>(null), expectedMessageRegExp);
             assert.throws(() => assertType<{ foo: number[] }>(true), expectedMessageRegExp);
         });
 
         it('should throw an error if objects where foo is not an array of numbers are passed to it', () => {
-            const expectedMessageRegExp1 = /validation failed at \$\.foo\.\[1\]: expected a number$/;
-            const expectedMessageRegExp2 = /validation failed at \$\.foo\.\[0\]: expected a number$/;
+            const expectedMessageRegExp1 = /validation failed at \$\.foo\.\[1\]: expected a number, found: .*$/;
+            const expectedMessageRegExp2 = /validation failed at \$\.foo\.\[0\]: expected a number, found: .*$/;
             assert.throws(() => assertType<{ foo: number[] }>({ foo: [0, '0'] }), expectedMessageRegExp1);
             assert.throws(() => assertType<{ foo: number[] }>({ foo: ['1'] }), expectedMessageRegExp2);
             assert.throws(() => assertType<{ foo: number[] }>({ foo: [{}] }), expectedMessageRegExp2);
@@ -77,7 +77,7 @@ describe('assertType', () => {
         });
 
         it('should throw an error if nested objects with foo not \'bar\' or \'baz\' are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$\.nested\.foo: there are no valid alternatives$/;
+            const expectedMessageRegExp = /validation failed at \$\.nested\.foo: there are no valid alternatives, found: .*$/;
             assert.throws(() => assertType<{ nested: Nested }>({ nested: { foo: 'qux' } }), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>({ nested: { foo: 0 } }), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>({ nested: { foo: [] } }), expectedMessageRegExp);
@@ -85,13 +85,13 @@ describe('assertType', () => {
         });
 
         it('should throw an error if nested objects without foo are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$\.nested: expected 'foo' in object$/;
+            const expectedMessageRegExp = /validation failed at \$\.nested: expected 'foo' in object, found: .*$/;
             assert.throws(() => assertType<{ nested: Nested }>({ nested: {} }), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>({ nested: { foh: 'bar' } }), expectedMessageRegExp);
         });
 
         it('should throw an error if nested properties that are not objects are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$\.nested: expected an object$/;
+            const expectedMessageRegExp = /validation failed at \$\.nested: expected an object, found: .*$/;
             assert.throws(() => assertType<{ nested: Nested }>({ nested: 0 }), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>({ nested: true }), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>({ nested: null }), expectedMessageRegExp);
@@ -99,13 +99,13 @@ describe('assertType', () => {
         });
 
         it('should throw an error if objects without nested are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected 'nested' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected 'nested' in object, found: .*$/;
             assert.throws(() => assertType<{ nested: Nested }>({ nisted: { foo: 'bar' } }), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>({ nisted: { foh: 'baz' } }), expectedMessageRegExp);
         });
 
         it('should throw an error if other objects are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected an object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected an object, found: .*$/;
             assert.throws(() => assertType<{ nested: Nested }>('0'), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>(1), expectedMessageRegExp);
             assert.throws(() => assertType<{ nested: Nested }>([]), expectedMessageRegExp);
@@ -122,8 +122,8 @@ describe('assertType', () => {
         });
 
         it('should throw an error if objects with non-boolen values are passed to it', () => {
-            const expectedMessageRegExp1 = /validation failed at \$\.foo: expected a boolean$/;
-            const expectedMessageRegExp2 = /validation failed at \$\.bar: expected a boolean$/;
+            const expectedMessageRegExp1 = /validation failed at \$\.foo: expected a boolean, found: .*$/;
+            const expectedMessageRegExp2 = /validation failed at \$\.bar: expected a boolean, found: .*$/;
             assert.throws(() => assertType<{ [Key: string]: boolean }>({ foo: 0 }), expectedMessageRegExp1);
             assert.throws(() => assertType<{ [Key: string]: boolean }>({ bar: 'foo' }), expectedMessageRegExp2);
             assert.throws(() => assertType<{ [Key: string]: boolean }>({ bar: [] }), expectedMessageRegExp2);

--- a/test/issue-22.ts
+++ b/test/issue-22.ts
@@ -1,5 +1,5 @@
 import * as assert from 'assert';
-import { equals, createEquals, assertEquals, createAssertEquals } from '../index';
+import { assertEquals, createAssertEquals, createEquals, equals } from '../index';
 
 /* https://github.com/woutervh-/typescript-is/issues/22 */
 
@@ -61,13 +61,13 @@ describe('assertEquals', () => {
         });
 
         it('should throw an error if objects without `foo` being a number are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object, found: .*$/;
             assert.throws(() => assertEquals<{ foo: number }>({}), expectedMessageRegExp);
             assert.throws(() => assertEquals<{ foo: number }>({ bar: 0 }), expectedMessageRegExp);
         });
 
         it('should throw an error if objects with `foo` being a number and with other properties are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: superfluous property 'bar' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: superfluous property 'bar' in object, found: .*$/;
             assert.throws(() => assertEquals<{ foo: number }>({ foo: 0, bar: 1 }), expectedMessageRegExp);
             assert.throws(() => assertEquals<{ foo: number }>({ foo: 0, bar: 'value' }), expectedMessageRegExp);
         });
@@ -88,13 +88,13 @@ describe('createAssertEquals', () => {
         });
 
         it('should throw an error if objects without `foo` being a number are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: expected 'foo' in object, found: .*$/;
             assert.throws(() => assertObject({}), expectedMessageRegExp);
             assert.throws(() => assertObject({ bar: 0 }), expectedMessageRegExp);
         });
 
         it('should throw an error if objects with `foo` being a number and with other properties are passed to it', () => {
-            const expectedMessageRegExp = /validation failed at \$: superfluous property 'bar' in object$/;
+            const expectedMessageRegExp = /validation failed at \$: superfluous property 'bar' in object, found: .*$/;
             assert.throws(() => assertObject({ foo: 0, bar: 1 }), expectedMessageRegExp);
             assert.throws(() => assertObject({ foo: 0, bar: 'value' }), expectedMessageRegExp);
         });


### PR DESCRIPTION
Fixes https://github.com/woutervh-/typescript-is/issues/57

Hi @woutervh- I took a stab at adding info about the input data to the error message of TypeGuardError. For example:

`'TypeGuardError: validation failed at undefined: expected a number, found: undefined'`
`'TypeGuardError: validation failed at $.children.[0].children: expected an array, found: null'`
`'TypeGuardError: validation failed at $.children: expected an array, found: "foo"'`

I'm not sure if you're OK with the error message including the data at the error path, but we've been using a custom catcher in some places which replaces the error message as defined in this PR and found it very helpful!

I was also considering adding an option to gate the printing of the "found" data into the error message but couldn't figure out how/wheter options can be accessed from index.js

Test plan: existing unit tests


