### PR TITLE
Reorder visitType check to fix bug

### DIFF
--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -694,9 +694,7 @@ function visitIndexedAccessType(type: ts.IndexedAccessType, visitorContext: Visi
 }
 
 export function visitType(type: ts.Type, visitorContext: VisitorContext): string {
-    if (type.aliasTypeArguments && visitorContext.previousTypeReference !== type && (type as ts.TypeReference).target) {
-        return visitTypeAliasReference(type as ts.TypeReference, visitorContext);
-    } else if ((ts.TypeFlags.Any & type.flags) !== 0) {
+    if ((ts.TypeFlags.Any & type.flags) !== 0) {
         // Any
         return visitAny(visitorContext);
     } else if ((ts.TypeFlags.Unknown & type.flags) !== 0) {
@@ -729,6 +727,8 @@ export function visitType(type: ts.Type, visitorContext: VisitorContext): string
     } else if (tsutils.isTypeReference(type) && visitorContext.previousTypeReference !== type) {
         // Type references.
         return visitTypeReference(type, visitorContext);
+    } else if (type.aliasTypeArguments && visitorContext.previousTypeReference !== type && (type as ts.TypeReference).target) {
+        return visitTypeAliasReference(type as ts.TypeReference, visitorContext);
     } else if ((ts.TypeFlags.TypeParameter & type.flags) !== 0) {
         // Type parameter
         return visitTypeParameter(type, visitorContext);

--- a/test/issue-88.ts
+++ b/test/issue-88.ts
@@ -1,0 +1,26 @@
+import * as assert from 'assert';
+import { is } from '../index';
+
+/* https://github.com/woutervh-/typescript-is/issues/88 */
+
+interface Z<T> {
+    field: T;
+}
+
+type Y<T> = Z<T>
+
+type X = Y<string>
+
+describe('is', () => {
+    describe('Parameterised type alias of a parameterised type alias of an interface', () => {
+        it('should return true for object with field type string', () => {
+            assert.deepStrictEqual(is<X>({ field: 'some-string' }), true);
+        });
+        it('should return false for object with field type number', () => {
+            assert.deepStrictEqual(is<X>({ field: 0 }), false);
+        });
+        it('should return false for object without field', () => {
+            assert.deepStrictEqual(is<X>({}), false);
+        });
+    });
+});


### PR DESCRIPTION
Fixes #88

I'm not sure whether there is any unintended consequences of reordering the steps in `visitType`, but the existing tests still pass, as does the new test.