### PR TITLE
remove duplicate type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -258,6 +258,10 @@ interface ExpectedNull {
     type: 'null';
 }
 
+/**
+ * a pair of `ts.TemplateLiteralType.texts` and the `intrinsicName`s for `ts.TemplateLiteralType.types`,
+ * @see https://github.com/microsoft/TypeScript/pull/40336
+ */
 type TemplateLiteralPair = [string, 'string' | 'number' | 'bigint' | 'any' | 'undefined' | 'null' | undefined];
 
 interface ExpectedTemplateLiteral {

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -7,6 +7,7 @@ import * as VisitorIndexedAccess from './visitor-indexed-access';
 import * as VisitorIsStringKeyof from './visitor-is-string-keyof';
 import * as VisitorTypeName from './visitor-type-name';
 import { sliceSet } from './utils';
+import {TemplateLiteralPair} from '../../index';
 
 function visitDateType(type: ts.ObjectType, visitorContext: VisitorContext) {
     const name = VisitorTypeName.visitType(type, visitorContext, { type: 'type-check' });
@@ -695,7 +696,7 @@ function visitTemplateLiteralType(type: ts.TemplateLiteralType, visitorContext: 
     const name = VisitorTypeName.visitType(type, visitorContext, {type: 'type-check'});
     const typePairs = type.texts.reduce((prev, curr, i: number) =>
             [...prev, [curr, typeof type.types[i] === 'undefined' ? undefined : VisitorUtils.getIntrinsicName(type.types[i])]] as never,
-        [] as VisitorUtils.TemplateLiteralPair[]
+        [] as TemplateLiteralPair[]
     )
     const templateLiteralTypeError = VisitorUtils.createErrorObject({
         type: 'template-literal',

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -4,12 +4,6 @@ import * as tsutils from 'tsutils/typeguard/3.0';
 import { VisitorContext } from './visitor-context';
 import { Reason } from '../../index';
 
-/**
- * a pair of {@link ts.TemplateLiteralType.texts} and the `intrinsicName`s for {@link ts.TemplateLiteralType.types},
- * @see https://github.com/microsoft/TypeScript/pull/40336
- */
-export type TemplateLiteralPair = [string, 'string' | 'number' | 'bigint' | 'any' | 'undefined' | 'null' | undefined];
-
 export const objectIdentifier = ts.createIdentifier('object');
 export const pathIdentifier = ts.createIdentifier('path');
 const keyIdentifier = ts.createIdentifier('key');


### PR DESCRIPTION
remove the `TemplateLiteralPair` type that was moved to `index.d.ts` to fix https://github.com/woutervh-/typescript-is/issues/93#issuecomment-803287815