### PR TITLE
Fix #56: Better error messages for nullable types

### DIFF
--- a/src/transform-inline/visitor-indexed-access.ts
+++ b/src/transform-inline/visitor-indexed-access.ts
@@ -26,7 +26,7 @@ function visitRegularObjectType(type: ts.ObjectType, indexType: ts.Type, visitor
                     ? VisitorUtils.getIgnoredTypeFunction(visitorContext)
                     : VisitorTypeCheck.visitType(propertyInfo.type!, visitorContext)
             );
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         } else {
             const strings = sliceSet(stringType);
             if (strings.some((value) => propertiesInfo.every((propertyInfo) => propertyInfo.name !== value))) {
@@ -38,7 +38,7 @@ function visitRegularObjectType(type: ts.ObjectType, indexType: ts.Type, visitor
                     ? VisitorUtils.getIgnoredTypeFunction(visitorContext)
                     : VisitorTypeCheck.visitType(propertyInfo.type!, visitorContext)
             );
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         }
     });
 }
@@ -55,14 +55,14 @@ function visitTupleObjectType(type: ts.TupleType, indexType: ts.Type, visitorCon
                 throw new Error('A non-number type was used to index a tuple type.');
             }
             const functionNames = type.typeArguments.map((type) => VisitorTypeCheck.visitType(type, visitorContext));
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         } else {
             const numbers = sliceSet(numberType);
             if (numbers.some((value) => value >= type.typeArguments!.length)) {
                 throw new Error('Indexed access on tuple type exceeds length of tuple.');
             }
             const functionNames = numbers.map((value) => VisitorTypeCheck.visitType(type.typeArguments![value], visitorContext));
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         }
     });
 }
@@ -102,7 +102,7 @@ function visitUnionOrIntersectionType(type: ts.UnionOrIntersectionType, indexTyp
             return VisitorUtils.createConjunctionFunction(functionNames, name);
         } else {
             // (T & U)[I] = T[I] | U[I]
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         }
     });
 }

--- a/src/transform-inline/visitor-keyof.ts
+++ b/src/transform-inline/visitor-keyof.ts
@@ -14,7 +14,7 @@ function visitUnionOrIntersectionType(type: ts.UnionOrIntersectionType, visitorC
             return VisitorUtils.createConjunctionFunction(functionNames, name);
         } else {
             // keyof (T & U) = (keyof T) | (keyof U)
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         }
     });
 }

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -546,7 +546,7 @@ function visitUnionOrIntersectionType(type: ts.UnionOrIntersectionType, visitorC
         const name = VisitorTypeName.visitType(type, visitorContext, { type: 'type-check' });
         const functionNames = typeUnion.types.map((type) => visitType(type, visitorContext));
         return VisitorUtils.setFunctionIfNotExists(name, visitorContext, () => {
-            return VisitorUtils.createDisjunctionFunction(functionNames, name);
+            return VisitorUtils.createDisjunctionFunction(functionNames, name, visitorContext);
         });
     }
     const intersectionType = type;

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -429,7 +429,15 @@ export function createConjunctionFunction(functionNames: string[], functionName:
     );
 }
 
-export function createDisjunctionFunction(functionNames: string[], functionName: string) {
+export function createDisjunctionFunction(functionNames: string[], functionName: string, visitorContext: VisitorContext) {
+    if (functionNames.length === 2) {
+        const nullTypeCheckFunction = getNullFunction(visitorContext);
+        const nullIndex = functionNames.indexOf(nullTypeCheckFunction);
+        if (nullIndex > -1) {
+            return createNullableTypeCheck(functionNames[1 - nullIndex], functionName);
+        }
+    }
+
     const conditionsIdentifier = ts.createIdentifier('conditions');
     const conditionIdentifier = ts.createIdentifier('condition');
     const errorIdentifier = ts.createIdentifier('error');
@@ -485,6 +493,31 @@ export function createDisjunctionFunction(functionNames: string[], functionName:
                 ])
             ),
             ts.createReturn(createErrorObject({ type: 'union' }))
+        ])
+    );
+}
+
+function createNullableTypeCheck(typeCheckFunction: string, functionName: string) {
+    return ts.createFunctionDeclaration(
+        undefined,
+        undefined,
+        undefined,
+        functionName,
+        undefined,
+        [
+            ts.createParameter(undefined, undefined, undefined, objectIdentifier, undefined, undefined, undefined)
+        ],
+        undefined,
+        ts.createBlock([
+            ts.createIf(
+                ts.createStrictEquality(objectIdentifier, ts.createNull()),
+                ts.createReturn(ts.createNull()),
+                ts.createReturn(ts.createCall(
+                    ts.createIdentifier(typeCheckFunction),
+                    undefined,
+                    [objectIdentifier]
+                ))
+            )
         ])
     );
 }

--- a/test/issue-56.ts
+++ b/test/issue-56.ts
@@ -1,0 +1,75 @@
+import { createAssertType, TypeGuardError } from '../index';
+import * as assert from 'assert';
+
+/* https://github.com/woutervh-/typescript-is/issues/56 */
+
+type NullableUnion = null | string;
+type NestedNullableUnion = {a: null | {b: null | {c: null | string}}};
+type SimpleUnion = null | string | boolean;
+
+describe('is', () => {
+  describe('createAssertType<null | string>', () => {
+    it('Should work if null is passed', () => {
+      createAssertType<NullableUnion>()(null);
+    })
+    it('Should work if string is passed', () => {
+      createAssertType<NullableUnion>()('string')
+    })
+    it('Should throw an error if number is passed', () => {
+      try {
+        createAssertType<NullableUnion>()(42);
+      } catch (error) {
+        assert.deepStrictEqual(error instanceof TypeGuardError, true);
+        assert.deepStrictEqual(error.message, 'validation failed at $: expected a string, found: 42');
+        assert.deepStrictEqual(error.path, ['$']);
+        assert.deepStrictEqual(error.reason, { type: 'string' });
+      }
+    });
+  });
+
+  describe('createAssertType<{a: null | {b: null | {c: null | string}}}>', () => {
+    it('Should work', () => {
+      createAssertType<NestedNullableUnion>()({a: null});
+      createAssertType<NestedNullableUnion>()({a: {b: null}});
+      createAssertType<NestedNullableUnion>()({a: {b: {c: null}}});
+      createAssertType<NestedNullableUnion>()({a: {b: {c: 'string'}}});
+    })
+    it('Should throw an error if number is passed instead of string', () => {
+      try {
+        createAssertType<NestedNullableUnion>()({a: {b: {c: 42}}});
+      } catch (error) {
+        assert.deepStrictEqual(error instanceof TypeGuardError, true);
+        assert.deepStrictEqual(error.message, 'validation failed at $.a.b.c: expected a string, found: 42');
+        assert.deepStrictEqual(error.path, ['$', 'a', 'b', 'c']);
+        assert.deepStrictEqual(error.reason, { type: 'string' });
+      }
+    });
+    it('Should throw an error if number is passed instead of object', () => {
+      try {
+        createAssertType<NestedNullableUnion>()({a: {b: 42}});
+      } catch (error) {
+        assert.deepStrictEqual(error instanceof TypeGuardError, true);
+        assert.deepStrictEqual(error.message, 'validation failed at $.a.b: expected an object, found: 42');
+        assert.deepStrictEqual(error.path, ['$', 'a', 'b']);
+        assert.deepStrictEqual(error.reason, { type: 'object' });
+      }
+    });
+  });
+  describe('createAssertType<string | boolean | null>', () => {
+    it('Should work', () => {
+      createAssertType<SimpleUnion>()(null);
+      createAssertType<SimpleUnion>()('string');
+      createAssertType<SimpleUnion>()(false);
+    })
+    it('Should throw an error if object is provided', () => {
+      try {
+        createAssertType<SimpleUnion>()({});
+      } catch (error) {
+        assert.deepStrictEqual(error instanceof TypeGuardError, true);
+        assert.deepStrictEqual(error.message, 'validation failed at $: there are no valid alternatives, found: {}');
+        assert.deepStrictEqual(error.path, ['$']);
+        assert.deepStrictEqual(error.reason, { type: 'union' });
+      }
+    });
+  });
+});


### PR DESCRIPTION
This fixes https://github.com/woutervh-/typescript-is/issues/56 by providing a better error message when a type is nullable. It only changes behaviour when a union contains 2 members (e.g. won't change behaviour for `a | b | c`) and when one of the union members is null `null | a`.

```
reateAssertType<{
  data: {
    node: { a: string; closed: string; b: string } | null;
  };
}>()({ data: { node: { a: "a", closed: false, b: "b" } } });

// Before:
// TypeGuardError: validation failed at $.data.node: there are no valid alternatives
// After: 
// TypeGuardError: validation failed at $.data.node.closed: expected a string, found: false
```
