### PR TITLE
Add an option to generate code without detailed error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ There are some options to configure the transformer.
 | `ignoreFunctions` *(deprecated, use `functionBehavior` instead)* | Boolean (default: `false`). If `true`, when the transformer encounters a function, it will ignore it and simply return `true`. If `false`, an error is generated at compile time. |
 | `functionBehavior` | One of `error`, `ignore`, or `basic` (default: `error`). Determines the behavior of transformer when encountering a function. `error` will cause a compile-time error, `ignore` will cause the validation function to always return `true`, and `basic` will do a simple function-type-check. Overrides `ignoreFunctions`. |
 | `disallowSuperfluousObjectProperties` | Boolean (default: `false`). If `true`, objects are checked for having superfluous properties and will cause the validation to fail if they do. If `false`, no check for superfluous properties is made. |
+| `emitDetailedErrors` | Boolean or `auto` (default: `auto`). The generated validation functions can return detailed error messages, pointing out where and why validation failed. These messages are used by `assertType<T>()`, but are ignored by `is<T>()`. If `false`, validation functions return empty error messages, decreasing code size. `auto` will generate detailed error messages for assertions, but not for type checks. `true` will always generate detailed error messages, matching the behaviour of version 0.18.3 and older. |
 
 If you are using `ttypescript`, you can include the options in your `tsconfig.json`:
 
@@ -150,7 +151,8 @@ If you are using `ttypescript`, you can include the options in your `tsconfig.js
                 "ignoreClasses": true,
                 "ignoreMethods": true,
                 "functionBehavior": "ignore",
-                "disallowSuperfluousObjectProperties": true
+                "disallowSuperfluousObjectProperties": true,
+                "emitDetailedErrors": "auto"
             }
         ]
     }

--- a/index.js
+++ b/index.js
@@ -19,6 +19,8 @@ function inputObjectAtPath(path, inputObject) {
 }
 
 function appendInputToErrorMessage(message, path, inputObject) {
+    if (message === undefined)
+        return 'validation error';
     const foundInputObject = inputObjectAtPath(path, inputObject);
     try {
         return message + ', found: ' + require('util').inspect(foundInputObject);

--- a/src/transform-inline/transform-node.ts
+++ b/src/transform-inline/transform-node.ts
@@ -105,6 +105,8 @@ export function transformNode(node: ts.Node, visitorContext: PartialVisitorConte
         ) {
             const name = visitorContext.checker.getTypeAtLocation(signature.declaration).symbol.name;
             const isEquals = name === 'equals' || name === 'createEquals' || name === 'assertEquals' || name === 'createAssertEquals';
+            const isAssert = name === 'assertEquals' || name === 'assertType' || name === 'createAssertEquals' || name === 'createAssertType';
+            const emitDetailedErrors = visitorContext.options.emitDetailedErrors === 'auto' ? isAssert : visitorContext.options.emitDetailedErrors;
 
             const typeArgument = node.typeArguments[0];
             const type = visitorContext.checker.getTypeFromTypeNode(typeArgument);
@@ -116,7 +118,8 @@ export function transformNode(node: ts.Node, visitorContext: PartialVisitorConte
                     ...visitorContext,
                     options: {
                         ...visitorContext.options,
-                        disallowSuperfluousObjectProperties: isEquals || visitorContext.options.disallowSuperfluousObjectProperties
+                        disallowSuperfluousObjectProperties: isEquals || visitorContext.options.disallowSuperfluousObjectProperties,
+                        emitDetailedErrors
                     }
                 }
             );

--- a/src/transform-inline/transformer.ts
+++ b/src/transform-inline/transformer.ts
@@ -18,6 +18,15 @@ function getFunctionBehavior(options?: { [Key: string]: unknown }): PartialVisit
     return 'error';
 }
 
+function getEmitDetailedErrors(options?: { [Key: string]: unknown }): PartialVisitorContext['options']['emitDetailedErrors'] {
+    if (options) {
+        if (options.emitDetailedErrors === 'auto' || typeof options.emitDetailedErrors === 'boolean') {
+            return options.emitDetailedErrors;
+        }
+    }
+    return 'auto';
+}
+
 export default function transformer(program: ts.Program, options?: { [Key: string]: unknown }): ts.TransformerFactory<ts.SourceFile> {
     if (options && options.verbose) {
         console.log(`typescript-is: transforming program with ${program.getSourceFiles().length} source files; using TypeScript ${ts.version}.`);
@@ -32,7 +41,8 @@ export default function transformer(program: ts.Program, options?: { [Key: strin
             ignoreClasses: !!(options && options.ignoreClasses),
             ignoreMethods: !!(options && options.ignoreMethods),
             functionBehavior: getFunctionBehavior(options),
-            disallowSuperfluousObjectProperties: !!(options && options.disallowSuperfluousObjectProperties)
+            disallowSuperfluousObjectProperties: !!(options && options.disallowSuperfluousObjectProperties),
+            emitDetailedErrors: getEmitDetailedErrors(options)
         },
         typeMapperStack: [],
         previousTypeReference: null

--- a/src/transform-inline/visitor-context.d.ts
+++ b/src/transform-inline/visitor-context.d.ts
@@ -6,6 +6,7 @@ interface Options {
     ignoreMethods: boolean;
     functionBehavior: 'error' | 'ignore' | 'basic';
     disallowSuperfluousObjectProperties: boolean;
+    emitDetailedErrors: boolean | 'auto';
 }
 
 export interface VisitorContext extends PartialVisitorContext {

--- a/src/transform-inline/visitor-keyof.ts
+++ b/src/transform-inline/visitor-keyof.ts
@@ -60,7 +60,8 @@ function visitRegularObjectType(type: ts.ObjectType, visitorContext: VisitorCont
             return VisitorUtils.createAssertionFunction(
                 condition,
                 { type: 'object-keyof', properties: names },
-                name
+                name,
+                visitorContext
             );
         });
     }

--- a/test/issue-16.ts
+++ b/test/issue-16.ts
@@ -36,7 +36,8 @@ describe('visitor', () => {
                     ignoreMethods: false,
                     functionBehavior: 'error',
                     shortCircuit: false,
-                    disallowSuperfluousObjectProperties: false
+                    disallowSuperfluousObjectProperties: false,
+                    emitDetailedErrors: 'auto'
                 },
                 typeMapperStack: [],
                 previousTypeReference: null
@@ -61,7 +62,8 @@ describe('visitor', () => {
                     ignoreMethods: false,
                     functionBehavior: 'error',
                     shortCircuit: false,
-                    disallowSuperfluousObjectProperties: false
+                    disallowSuperfluousObjectProperties: false,
+                    emitDetailedErrors: 'auto'
                 },
                 typeMapperStack: [],
                 previousTypeReference: null
@@ -90,7 +92,8 @@ describe('visitor', () => {
                 ignoreMethods: true,
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null
@@ -118,7 +121,8 @@ describe('visitor', () => {
                 ignoreMethods: false,
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null
@@ -146,7 +150,8 @@ describe('visitor', () => {
                 ignoreMethods: true,
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null

--- a/test/issue-27.ts
+++ b/test/issue-27.ts
@@ -34,7 +34,8 @@ describe('visitor', () => {
                 ignoreMethods: true,
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null

--- a/test/issue-3.ts
+++ b/test/issue-3.ts
@@ -35,7 +35,8 @@ describe('visitor', () => {
                 ignoreMethods: false,
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null

--- a/test/issue-31.ts
+++ b/test/issue-31.ts
@@ -45,7 +45,8 @@ describe('visitor', () => {
             ignoreMethods: true, // Make sure it does not fail on the methods.
             functionBehavior: 'error',
             shortCircuit: false,
-            disallowSuperfluousObjectProperties: false
+            disallowSuperfluousObjectProperties: false,
+            emitDetailedErrors: 'auto'
         };
         const visitorContext = createVisitorContext(program, options);
         const visitorContextWithDate = createVisitorContext(programWithDate, options);
@@ -77,7 +78,8 @@ describe('visitor', () => {
             ignoreMethods: false, // It should never get to the methods of the class.
             functionBehavior: 'error',
             shortCircuit: false,
-            disallowSuperfluousObjectProperties: false
+            disallowSuperfluousObjectProperties: false,
+            emitDetailedErrors: 'auto'
         };
         const visitorContext = createVisitorContext(program, options);
         const visitorContextWithDate = createVisitorContext(programWithDate, options);

--- a/test/issue-50.ts
+++ b/test/issue-50.ts
@@ -35,7 +35,8 @@ describe('visitor', () => {
                 ignoreMethods: true, // Make sure that the function is not seen as a method.
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null
@@ -63,7 +64,8 @@ describe('visitor', () => {
                 ignoreMethods: false,
                 functionBehavior: 'ignore',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null

--- a/test/issue-52.ts
+++ b/test/issue-52.ts
@@ -35,7 +35,8 @@ describe('visitor', () => {
                 ignoreMethods: true, // Make sure that the function is not seen as a method.
                 functionBehavior: 'error',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null
@@ -63,7 +64,8 @@ describe('visitor', () => {
                 ignoreMethods: false,
                 functionBehavior: 'ignore',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null
@@ -91,7 +93,8 @@ describe('visitor', () => {
                 ignoreMethods: false,
                 functionBehavior: 'basic',
                 shortCircuit: false,
-                disallowSuperfluousObjectProperties: false
+                disallowSuperfluousObjectProperties: false,
+                emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
             previousTypeReference: null


### PR DESCRIPTION
Hello,

Currently, `typescript-is` generates verbose error messages even for `is<T>`, where those messages are ignored. This increases code size for no good reason. I don't use `shortCircuit` in production, because I'm using `typescript-is` for validating untrusted input.

This set of patches adds an option to generate code returning `{}` for errors. The default, `auto`, will keep error messages for assertions, but remove them for `is<T>` et al, because they are ignored anyway. Setting it to `false` will skip all error messages for production builds.

All tests pass, but since this is my first time working with typescript transformers, a review is appreciated. Let me know if you need further changes.