### PR TITLE
Fix #111: Intersection disables disallowSuperfluousProperties

### DIFF
--- a/src/transform-inline/visitor-context.d.ts
+++ b/src/transform-inline/visitor-context.d.ts
@@ -11,6 +11,7 @@ interface Options {
 export interface VisitorContext extends PartialVisitorContext {
     functionNames: Set<string>;
     functionMap: Map<string, ts.FunctionDeclaration>;
+    overrideDisallowSuperfluousObjectProperies?: boolean;
 }
 
 export interface PartialVisitorContext {

--- a/src/transform-inline/visitor-type-check.ts
+++ b/src/transform-inline/visitor-type-check.ts
@@ -541,6 +541,11 @@ function visitLiteralType(type: ts.LiteralType, visitorContext: VisitorContext) 
 }
 
 function visitUnionOrIntersectionType(type: ts.UnionOrIntersectionType, visitorContext: VisitorContext) {
+    let disallowSuperfluousPropertyCheck = visitorContext.options.disallowSuperfluousObjectProperties;
+    if (visitorContext.overrideDisallowSuperfluousObjectProperies) {
+        visitorContext.overrideDisallowSuperfluousObjectProperies = false;
+        disallowSuperfluousPropertyCheck = false;
+    }
     const typeUnion = type;
     if (tsutils.isUnionType(typeUnion)) {
         const name = VisitorTypeName.visitType(type, visitorContext, { type: 'type-check' });
@@ -553,8 +558,8 @@ function visitUnionOrIntersectionType(type: ts.UnionOrIntersectionType, visitorC
     if (tsutils.isIntersectionType(intersectionType)) {
         const name = VisitorTypeName.visitType(type, visitorContext, { type: 'type-check', superfluousPropertyCheck: visitorContext.options.disallowSuperfluousObjectProperties });
         return VisitorUtils.setFunctionIfNotExists(name, visitorContext, () => {
-            const functionNames = intersectionType.types.map((type) => visitType(type, { ...visitorContext, options: { ...visitorContext.options, disallowSuperfluousObjectProperties: false } }));
-            if (visitorContext.options.disallowSuperfluousObjectProperties) {
+            const functionNames = intersectionType.types.map((type) => visitType(type, { ...visitorContext, overrideDisallowSuperfluousObjectProperies: true }));
+            if (disallowSuperfluousPropertyCheck) {
                 // Check object keys at intersection type level. https://github.com/woutervh-/typescript-is/issues/21
                 const keys = VisitorIsStringKeyof.visitType(type, visitorContext);
                 if (keys instanceof Set) {

--- a/test/issue-111.ts
+++ b/test/issue-111.ts
@@ -1,0 +1,40 @@
+import * as assert from 'assert';
+import { assertEquals } from '../index';
+
+/* https://github.com/woutervh-/typescript-is/issues/111 */
+
+    // To properly test this issue, set disallowSuperfluousObjectProperties to `true` in the configuration.
+    // Then inspect the generated code to see if the keys of the object are checked properly.
+
+describe('assertEquals', () => {
+    describe('assertEquals<BarIntersection>', () => {
+        type Foo = {
+            quux: string;
+        };
+
+        type BarIntersection = {
+            foo: Foo;
+        } & {
+            bar: string;
+        };
+
+        type BarNotIntersection = {
+            foo: Foo;
+            bar: string;
+        };
+
+        const document = {
+            bar: 'bar',
+            foo: {
+                quux: 'quux',
+                super: 'fluous'
+            }
+        };
+
+        it('should throw with invalid objects', () => {
+            assert.throws(() => assertEquals<Foo>(document.foo));
+            assert.throws(() => assertEquals<BarNotIntersection>(document));
+            assert.throws(() => assertEquals<BarIntersection>(document));
+        });
+    });
+});


### PR DESCRIPTION
Fixes #111. Possibly. It's kinda hacky, but I don't know the code well enough to do something better. Doesn't seem to break the tests at this point in any way.