### PR TITLE
Fix #113: Make generated function names inside arrow-function deterministic in watch-mode runs and in recompiles

### DIFF
--- a/src/transform-inline/transform-node.ts
+++ b/src/transform-inline/transform-node.ts
@@ -8,7 +8,8 @@ import { sliceMapValues } from './utils';
 function createArrowFunction(type: ts.Type, rootName: string, optional: boolean, partialVisitorContext: PartialVisitorContext) {
     const functionMap: VisitorContext['functionMap'] = new Map();
     const functionNames: VisitorContext['functionNames'] = new Set();
-    const visitorContext = { ...partialVisitorContext, functionNames, functionMap };
+    const typeIdMap: VisitorContext['typeIdMap'] = new Map();
+    const visitorContext = { ...partialVisitorContext, functionNames, functionMap, typeIdMap };
     const functionName = partialVisitorContext.options.shortCircuit
         ? visitShortCircuit(visitorContext)
         : (optional

--- a/src/transform-inline/visitor-context.d.ts
+++ b/src/transform-inline/visitor-context.d.ts
@@ -11,6 +11,7 @@ interface Options {
 export interface VisitorContext extends PartialVisitorContext {
     functionNames: Set<string>;
     functionMap: Map<string, ts.FunctionDeclaration>;
+    typeIdMap: Map<string, string>;
 }
 
 export interface PartialVisitorContext {


### PR DESCRIPTION
This fixes https://github.com/woutervh-/typescript-is/issues/113

I was debugging the reason of why so many compiled files are changed in our project when a (seemingly unrelated) file change is made, and I found out that typescript-is re-generates the validators code on every change, even when the file isn't changed itself.

_Why non-deterministic code generation is a problem?_ Because the output of tsc may be consumed by other tools (in our case, it's consumed by webpack). So every time something unrelated is changed, webpack has to wake up and do a useless CPU work slowing down everything.

The idea in this PR is to not use type.id directly, but instead have a map of `typeId->index` inside the context and use that `index` instead of typeId. Once we see a new typeId, we add a new entry to the map. So in terms of the functionality, this is identical to what we had before, but now the code generated is deterministic.

**Before this PR**

<img width="1295" alt="Screen Shot 2021-10-28 at 12 15 56 PM" src="https://user-images.githubusercontent.com/46383452/139321115-a5d2735a-49fb-4917-807b-ef500acd085d.png">

Notice that the numbers used in generated function names (`_194`, `_11` etc.) are arbitrary and non-deterministic, so when something in the compilation changes during the watch-mode tsc build, these numbers may drift.

**After this PR**

<img width="1299" alt="Screen Shot 2021-10-28 at 12 16 11 PM" src="https://user-images.githubusercontent.com/46383452/139321285-894571fd-4501-4e5a-8bbe-47033bab4fe4.png">

Notice that numbers are now deterministic and start from 0 (e.g. `_0`, `_3`).

