### PR TITLE
feat: support symlinked packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 lib/
 test/*.js
 .idea
+*.tgz
+.vscode/

--- a/src/transform-inline/transform-node.ts
+++ b/src/transform-inline/transform-node.ts
@@ -58,7 +58,7 @@ function transformDecorator(node: ts.Decorator, parameterType: ts.Type, paramete
         if (
             signature !== undefined
             && signature.declaration !== undefined
-            && path.resolve(signature.declaration.getSourceFile().fileName) === path.resolve(path.join(__dirname, '..', '..', 'index.d.ts'))
+            && VisitorUtils.getCanonicalPath(path.resolve(signature.declaration.getSourceFile().fileName), visitorContext) === path.resolve(path.join(__dirname, '..', '..', 'index.d.ts'))
             && node.expression.arguments.length <= 1
         ) {
             const arrowFunction: ts.Expression = createArrowFunction(parameterType, parameterName, optional, visitorContext);
@@ -102,7 +102,7 @@ export function transformNode(node: ts.Node, visitorContext: PartialVisitorConte
         if (
             signature !== undefined
             && signature.declaration !== undefined
-            && path.resolve(signature.declaration.getSourceFile().fileName) === path.resolve(path.join(__dirname, '..', '..', 'index.d.ts'))
+            && VisitorUtils.getCanonicalPath(path.resolve(signature.declaration.getSourceFile().fileName), visitorContext) === path.resolve(path.join(__dirname, '..', '..', 'index.d.ts'))
             && node.typeArguments !== undefined
             && node.typeArguments.length === 1
         ) {

--- a/src/transform-inline/transformer.ts
+++ b/src/transform-inline/transformer.ts
@@ -46,7 +46,8 @@ export default function transformer(program: ts.Program, options?: { [Key: strin
             emitDetailedErrors: getEmitDetailedErrors(options)
         },
         typeMapperStack: [],
-        previousTypeReference: null
+        previousTypeReference: null,
+        canonicalPaths: new Map()
     };
     return (context: ts.TransformationContext) => (file: ts.SourceFile) => transformNodeAndChildren(file, program, context, visitorContext);
 }

--- a/src/transform-inline/visitor-context.d.ts
+++ b/src/transform-inline/visitor-context.d.ts
@@ -24,4 +24,5 @@ export interface PartialVisitorContext {
     options: Options;
     typeMapperStack: Map<ts.Type, ts.Type>[];
     previousTypeReference: ts.Type | null;
+    canonicalPaths: Map<string, string>;
 }

--- a/src/transform-inline/visitor-utils.ts
+++ b/src/transform-inline/visitor-utils.ts
@@ -1,7 +1,8 @@
 import * as ts from 'typescript';
+import * as fs from 'fs';
 import { ModifierFlags } from 'typescript';
 import * as tsutils from 'tsutils/typeguard/3.0';
-import { VisitorContext } from './visitor-context';
+import { PartialVisitorContext, VisitorContext } from './visitor-context';
 import { Reason } from '../../index';
 
 /**
@@ -730,4 +731,11 @@ function createErrorMessage(reason: Reason): ts.Expression {
 export function getIntrinsicName(type: ts.Type): string | undefined {
     // Using internal TypeScript API, hacky.
     return (type as { intrinsicName?: string }).intrinsicName;
+}
+
+export function getCanonicalPath(path: string, context: PartialVisitorContext): string {
+    if (!context.canonicalPaths.has(path)) {
+        context.canonicalPaths.set(path, fs.realpathSync(path));
+    }
+    return context.canonicalPaths.get(path)!;
 }

--- a/test-fixtures/issue-104.js
+++ b/test-fixtures/issue-104.js
@@ -1,0 +1,152 @@
+"use strict";
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : adopt(result.value).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AsyncMethods = void 0;
+const index_1 = require("../index");
+let AsyncMethods = class AsyncMethods {
+    asyncMethod(body) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return true;
+        });
+    }
+    asyncMethodNoExplicitReturn(body) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return true;
+        });
+    }
+    promiseReturnMethod(body) {
+        return Promise.resolve(true);
+    }
+    asyncOverride(body) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return true;
+        });
+    }
+    promiseOrOtherReturnMethod(body) {
+        return Promise.resolve(true);
+    }
+};
+__decorate([
+    __param(0, index_1.AssertType(object => { var path = ["body"]; function _string(object) { ; if (typeof object !== "string")
+        return { message: "validation failed at " + path.join(".") + ": expected a string", path: path.slice(), reason: { type: "string" } };
+    else
+        return null; } function _0(object) { ; if (typeof object !== "object" || object === null || Array.isArray(object))
+        return { message: "validation failed at " + path.join(".") + ": expected an object", path: path.slice(), reason: { type: "object" } }; {
+        if ("test" in object) {
+            path.push("test");
+            var error = _string(object["test"]);
+            path.pop();
+            if (error)
+                return error;
+        }
+        else
+            return { message: "validation failed at " + path.join(".") + ": expected 'test' in object", path: path.slice(), reason: { type: "missing-property", property: "test" } };
+    } return null; } return _0(object); })),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], AsyncMethods.prototype, "asyncMethod", null);
+__decorate([
+    __param(0, index_1.AssertType(object => { var path = ["body"]; function _string(object) { ; if (typeof object !== "string")
+        return { message: "validation failed at " + path.join(".") + ": expected a string", path: path.slice(), reason: { type: "string" } };
+    else
+        return null; } function _0(object) { ; if (typeof object !== "object" || object === null || Array.isArray(object))
+        return { message: "validation failed at " + path.join(".") + ": expected an object", path: path.slice(), reason: { type: "object" } }; {
+        if ("test" in object) {
+            path.push("test");
+            var error = _string(object["test"]);
+            path.pop();
+            if (error)
+                return error;
+        }
+        else
+            return { message: "validation failed at " + path.join(".") + ": expected 'test' in object", path: path.slice(), reason: { type: "missing-property", property: "test" } };
+    } return null; } return _0(object); })),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], AsyncMethods.prototype, "asyncMethodNoExplicitReturn", null);
+__decorate([
+    __param(0, index_1.AssertType(object => { var path = ["body"]; function _string(object) { ; if (typeof object !== "string")
+        return { message: "validation failed at " + path.join(".") + ": expected a string", path: path.slice(), reason: { type: "string" } };
+    else
+        return null; } function _0(object) { ; if (typeof object !== "object" || object === null || Array.isArray(object))
+        return { message: "validation failed at " + path.join(".") + ": expected an object", path: path.slice(), reason: { type: "object" } }; {
+        if ("test" in object) {
+            path.push("test");
+            var error = _string(object["test"]);
+            path.pop();
+            if (error)
+                return error;
+        }
+        else
+            return { message: "validation failed at " + path.join(".") + ": expected 'test' in object", path: path.slice(), reason: { type: "missing-property", property: "test" } };
+    } return null; } return _0(object); })),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], AsyncMethods.prototype, "promiseReturnMethod", null);
+__decorate([
+    __param(0, index_1.AssertType(object => { var path = ["body"]; function _string(object) { ; if (typeof object !== "string")
+        return { message: "validation failed at " + path.join(".") + ": expected a string", path: path.slice(), reason: { type: "string" } };
+    else
+        return null; } function _0(object) { ; if (typeof object !== "object" || object === null || Array.isArray(object))
+        return { message: "validation failed at " + path.join(".") + ": expected an object", path: path.slice(), reason: { type: "object" } }; {
+        if ("test" in object) {
+            path.push("test");
+            var error = _string(object["test"]);
+            path.pop();
+            if (error)
+                return error;
+        }
+        else
+            return { message: "validation failed at " + path.join(".") + ": expected 'test' in object", path: path.slice(), reason: { type: "missing-property", property: "test" } };
+    } return null; } return _0(object); }, { async: false })),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Promise)
+], AsyncMethods.prototype, "asyncOverride", null);
+__decorate([
+    __param(0, index_1.AssertType(object => { var path = ["body"]; function _string(object) { ; if (typeof object !== "string")
+        return { message: "validation failed at " + path.join(".") + ": expected a string", path: path.slice(), reason: { type: "string" } };
+    else
+        return null; } function _0(object) { ; if (typeof object !== "object" || object === null || Array.isArray(object))
+        return { message: "validation failed at " + path.join(".") + ": expected an object", path: path.slice(), reason: { type: "object" } }; {
+        if ("test" in object) {
+            path.push("test");
+            var error = _string(object["test"]);
+            path.pop();
+            if (error)
+                return error;
+        }
+        else
+            return { message: "validation failed at " + path.join(".") + ": expected 'test' in object", path: path.slice(), reason: { type: "missing-property", property: "test" } };
+    } return null; } return _0(object); })),
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", Object)
+], AsyncMethods.prototype, "promiseOrOtherReturnMethod", null);
+AsyncMethods = __decorate([
+    index_1.ValidateClass()
+], AsyncMethods);
+exports.AsyncMethods = AsyncMethods;

--- a/test/issue-16.ts
+++ b/test/issue-16.ts
@@ -41,7 +41,8 @@ describe('visitor', () => {
                     emitDetailedErrors: 'auto'
                 },
                 typeMapperStack: [],
-                previousTypeReference: null
+                previousTypeReference: null,
+                canonicalPaths: new Map()
             };
 
             function visitNodeAndChildren(node: ts.Node) {
@@ -68,7 +69,8 @@ describe('visitor', () => {
                     emitDetailedErrors: 'auto'
                 },
                 typeMapperStack: [],
-                previousTypeReference: null
+                previousTypeReference: null,
+                canonicalPaths: new Map()
             };
 
             function visitNodeAndChildren(node: ts.Node) {
@@ -99,8 +101,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
@@ -129,8 +132,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
@@ -159,8 +163,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);

--- a/test/issue-27.ts
+++ b/test/issue-27.ts
@@ -39,8 +39,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);

--- a/test/issue-3.ts
+++ b/test/issue-3.ts
@@ -40,8 +40,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);

--- a/test/issue-31.ts
+++ b/test/issue-31.ts
@@ -29,7 +29,8 @@ function createVisitorContext(program: Program, optionsDict: PartialVisitorConte
         compilerOptions: program.getCompilerOptions(),
         options: optionsDict,
         typeMapperStack: [],
-        previousTypeReference: null
+        previousTypeReference: null,
+        canonicalPaths: new Map()
     };
 }
 

--- a/test/issue-50.ts
+++ b/test/issue-50.ts
@@ -40,8 +40,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
@@ -70,8 +71,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);

--- a/test/issue-52.ts
+++ b/test/issue-52.ts
@@ -40,8 +40,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
@@ -70,8 +71,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);
@@ -100,8 +102,9 @@ describe('visitor', () => {
                 emitDetailedErrors: 'auto'
             },
             typeMapperStack: [],
-            previousTypeReference: null
-        };
+        previousTypeReference: null,
+        canonicalPaths: new Map()
+    };
 
         function visitNodeAndChildren(node: ts.Node) {
             ts.forEachChild(transformNode(node, visitorContext), visitNodeAndChildren);


### PR DESCRIPTION
When using package managers like `pnpm` or `yarn v3` with the `pnpm` linker, the current check for methods that come from this library doesn't work. The reason is that `path.resolve(signature.declaration.getSourceFile().fileName` is a path like `node_modules/typescript-is/index.d.ts`, but `path.resolve(path.join(__dirname, '..', '..', 'index.d.ts'))` looks like this `node_modules/.store/typescript-is-virtual-6354fcdb88/node_modules/typescript-is/index.d.ts`. The former folder is a symlink to the latter.

Using `fs.realpathSync` we can resolve the symlinked path to the real one and make sure the transformer works in these contexts.

I threw in some caching for the lookup via `PartialVisitorContext.canonicalPaths`, if this isn't desired, it also works using `fs` directly.