### PR TITLE
allow CustomError per AssertType decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,25 @@ new A().method(42) === 42; // true
 new A().method('42' as any); // will throw error
 ```
 
+You can pass a custom error class both on `ValidateClass` and on `AssertType`
+
+```typescript
+import { ValidateClass, AssertType } from 'typescript-is';
+
+class E1 extends Error { }
+class E2 extends Error { }
+
+@ValidateClass(E1)
+class C {
+    method1(@AssertType() value: number) { }
+    method1(@AssertType({errorConstructor:E2}) value: number) { }
+}
+
+new C().method1('42' as any) // will throw E1
+new C().method2('42' as any) // will throw E2
+```
+
+
 ### async and `Promise` returning methods 
 `AssertType` can also work correctly with `async` methods, returning promise rejected with `TypeGuardError`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ export function createAssertEquals<T>(): (object: any) => T;
    new A().method('0' as any); // will throw an error
    ```
  */
-export function AssertType(options?: { async: boolean, errorConstructor: { new(): Error } | null }): (target: object, propertyKey: string | symbol, parameterIndex: number) => void;
+export function AssertType(options?: { async?: boolean, errorConstructor?: { new(): Error } }): (target: object, propertyKey: string | symbol, parameterIndex: number) => void;
 
 /**
  * Overrides methods in the target class with a proxy that will first validate the argument types.

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,7 +125,7 @@ export function createAssertEquals<T>(): (object: any) => T;
    new A().method('0' as any); // will throw an error
    ```
  */
-export function AssertType(options?: { async: boolean }): (target: object, propertyKey: string | symbol, parameterIndex: number) => void;
+export function AssertType(options?: { async: boolean, errorConstructor: { new(): Error } | null }): (target: object, propertyKey: string | symbol, parameterIndex: number) => void;
 
 /**
  * Overrides methods in the target class with a proxy that will first validate the argument types.

--- a/index.js
+++ b/index.js
@@ -70,8 +70,8 @@ function ValidateClass(errorConstructor = TypeGuardError) {
                         }
                         const errorObject = assertions[i].assertion(args[i]);
                         if (errorObject !== null) {
-                            if (assertions[i].errorConstructor) {
-                                errorConstructor = assertions[i].errorConstructor;
+                            if (assertions[i].options.errorConstructor) {
+                                errorConstructor = assertions[i].options.errorConstructor;
                             }
                             const errorInstance = new errorConstructor(errorObject, args[i]);
                             if(assertions[i].options.async) {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class TypeGuardError extends Error {
     }
 }
 
-function AssertType(assertion, options = {}) {
+function AssertType(assertion, options = { errorConstructor: null }) {
     require('reflect-metadata');
     return function (target, propertyKey, parameterIndex) {
         const assertions = Reflect.getOwnMetadata(assertionsMetadataKey, target, propertyKey) || [];
@@ -70,6 +70,9 @@ function ValidateClass(errorConstructor = TypeGuardError) {
                         }
                         const errorObject = assertions[i].assertion(args[i]);
                         if (errorObject !== null) {
+                            if (assertions[i].errorConstructor) {
+                                errorConstructor = assertions[i].errorConstructor;
+                            }
                             const errorInstance = new errorConstructor(errorObject, args[i]);
                             if(assertions[i].options.async) {
                                 return Promise.reject(errorInstance);

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ class TypeGuardError extends Error {
     }
 }
 
-function AssertType(assertion, options = { errorConstructor: null }) {
+function AssertType(assertion, options = {}) {
     require('reflect-metadata');
     return function (target, propertyKey, parameterIndex) {
         const assertions = Reflect.getOwnMetadata(assertionsMetadataKey, target, propertyKey) || [];

--- a/test/issue-129.ts
+++ b/test/issue-129.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:max-classes-per-file */
 
 import * as assert from 'assert';
-import { assertEquals } from '../index';
+import { AssertType, ValidateClass } from '../index';
 
 /* https://github.com/woutervh-/typescript-is/issues/129 */
 
@@ -20,6 +20,7 @@ describe('AssertType', () => {
             return parameter;
         }
     }
+    const instance = new TestClass();
 
     it('should allow custom error class', () => {
         assert.throws(() => instance.testMethod(0 as any), expectedMessageRegExp);

--- a/test/issue-129.ts
+++ b/test/issue-129.ts
@@ -1,0 +1,30 @@
+import * as assert from 'assert';
+import { assertEquals } from '../index';
+
+/* https://github.com/woutervh-/typescript-is/issues/129 */
+
+describe('AssertType', () => {
+    const expectedMessageRegExp = /Custom error.$/;
+
+    class CustomError extends Error {
+        constructor() {
+            super('Custom error.');
+        }
+    }
+
+    @ValidateClass()
+    class TestClass {
+        testMethod(@AssertType({errorConstructor: CustomError}) parameter: boolean) {
+            return parameter;
+        }
+    }
+
+    it('should allow custom error class', () => {
+        assert.throws(() => instance.testMethod(0 as any), expectedMessageRegExp);
+        assert.throws(() => instance.testMethod(1 as any), expectedMessageRegExp);
+        assert.throws(() => instance.testMethod('' as any), expectedMessageRegExp);
+        assert.throws(() => instance.testMethod('true' as any), expectedMessageRegExp);
+        assert.throws(() => instance.testMethod({} as any), expectedMessageRegExp);
+        assert.throws(() => instance.testMethod([] as any), expectedMessageRegExp);
+    });
+});

--- a/test/issue-129.ts
+++ b/test/issue-129.ts
@@ -1,3 +1,5 @@
+/* tslint:disable:max-classes-per-file */
+
 import * as assert from 'assert';
 import { assertEquals } from '../index';
 


### PR DESCRIPTION
I had some free time and tried to do the appropriate changes to have custom errorclass per decorator, as requested in #129 